### PR TITLE
Fixed xDscResourceDesigner blank exit code installation failures. Fixes #8

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -12,13 +12,13 @@ if (!$PSScriptRoot) # $PSScriptRoot is not defined in 2.0
 # Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Force
 
+# Load the TestHelper module which contains the Get-ResourceDesigner function
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'TestHelper.psm1') -Force
+
 $ErrorActionPreference = 'stop'
 Set-StrictMode -Version latest
 
 $RepoRoot = (Resolve-Path $PSScriptRoot\..).Path
-
-# Load the TestHelper module which contains the Get-ResourceDesigner function
-Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'TestHelper.psm1') -Force
 
 Get-ResourceDesigner
 

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -1,9 +1,15 @@
 <# 
-.summary
-    Test that describes code.
+    .summary
+        Test that describes code.
+
+    .PARAMETER Force
+        Used to force any installations to occur without confirming with
+        the user.
 #>
 [CmdletBinding()]
-param()
+Param (
+    [Boolean]$Force = $false
+)
 
 if (!$PSScriptRoot) # $PSScriptRoot is not defined in 2.0
 {
@@ -12,7 +18,7 @@ if (!$PSScriptRoot) # $PSScriptRoot is not defined in 2.0
 # Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Force
 
-# Load the TestHelper module which contains the Get-ResourceDesigner function
+# Load the TestHelper module which contains the *-ResourceDesigner functions
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'TestHelper.psm1') -Force
 
 $ErrorActionPreference = 'stop'
@@ -20,7 +26,12 @@ Set-StrictMode -Version latest
 
 $RepoRoot = (Resolve-Path $PSScriptRoot\..).Path
 
-Get-ResourceDesigner
+# Install and/or Import xDSCResourceDesigner Module
+if ($env:APPVEYOR) {
+    # Running in AppVeyor so force silent install of xDSCResourceDesigner
+    $PSBoundParameters.Force = $true
+}
+Import-ResourceDesigner @PSBoundParameters
 
 # Modify PSModulePath of the current PowerShell session.
 # We want to make sure we always test the development version of the resource

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -9,6 +9,8 @@ if (!$PSScriptRoot) # $PSScriptRoot is not defined in 2.0
 {
     $PSScriptRoot = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
 }
+# Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Force
 
 $ErrorActionPreference = 'stop'
 Set-StrictMode -Version latest
@@ -27,9 +29,6 @@ if (($env:PSModulePath.Split(';') | Select-Object -First 1) -ne $pwd)
 {
     $env:PSModulePath = "$pwd;$env:PSModulePath"
 }
-
-# Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
-Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Force
 
 Describe 'Text files formatting' {
     

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -31,7 +31,21 @@ if ($env:APPVEYOR) {
     # Running in AppVeyor so force silent install of xDSCResourceDesigner
     $PSBoundParameters.Force = $true
 }
-Import-ResourceDesigner @PSBoundParameters
+
+$xDSCResourceDesignerModule = Install-ResourceDesigner @PSBoundParameters
+if ($xDSCResourceDesignerModule) {
+    # Import the module if it is available
+    $xDSCResourceDesignerModule | Import-Module -Force
+}
+else
+{
+    # Module could not/would not be installed - so warn user that tests will fail.
+    Write-Warning -Message ( @(
+        "The 'xDSCResourceDesigner' module is not installed. "
+        "The 'PowerShell DSC resource modules' Pester Tests in Meta.Tests.ps1 "
+        'will fail until this module is installed.'
+        ) -Join '' )
+}
 
 # Modify PSModulePath of the current PowerShell session.
 # We want to make sure we always test the development version of the resource

--- a/README.md
+++ b/README.md
@@ -60,24 +60,5 @@ The test helper module contains cmdlets for assiting in either running standard 
 Resource Pester tests or creating a NuGet package from the build.
 
 ## Example Usage in AppVeyor.yml
-To automatically download and install the DscResource.Tests in an AppVeyor.yml file, add
-the following to the install section:
-
-```
-install:
-  - cinst -y pester
-  - git clone https://github.com/PowerShell/DscResource.Tests
-  - ps: Import-Module .\DscResource.Tests\TestHelper.psm1 -force
-```
-
-The test_script section should contain code similar to:
-```
-test_script:
-    - ps: |
-        $testResultsFile = ".\TestsResults.xml"
-        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
-        (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        if ($res.FailedCount -gt 0) { 
-            throw "$($res.FailedCount) tests failed."
-        }
-```
+To automatically download and install the DscResource.Tests in an AppVeyor.yml file, please see the following sample AppVeyor.yml.
+[https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/appveyor.yml](https://github.com/PowerShell/DscResources/blob/master/DscResource.Template/appveyor.yml)

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -170,7 +170,7 @@ function Install-ResourceDesigner {
             -f $Script:DesignerModuleName,$nugetSource)))
     {
         # Use Nuget.exe to install the module
-        & "$nugetPath" @( `
+        $null = & "$nugetPath" @( `
             'install', $Script:DesignerModuleName, `
             '-source', $nugetSource, `
             '-outputDirectory', $OutputDirectory, `

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -82,46 +82,12 @@ function New-Nuspec
 
 <#
     .SYNOPSIS
-        Will attempt to install the xDSCResourceDesignerModule and import it.
-
-    .PARAMETER Force
-        Used to force any installations to occur without confirming with
-        the user.
-            
-    .EXAMPLE
-        Import-ResourceDesigner
-
-#>
-function Import-ResourceDesigner {
-    [CmdletBinding(
-        SupportsShouldProcess = $true
-    )]
-    Param (
-        [Boolean]$Force = $false
-    )
-   
-    Install-ResourceDesigner @PSBoundParameters
-
-    if (@(Get-Module -Name $Script:DesignerModuleName -ListAvailable).Count -ne 0)
-    {
-        # Import the module using the name if it is available
-        Import-Module -Name $Script:DesignerModuleName -Force
-    }
-    else
-    {
-        Write-Warning -Message ( @(
-            "The '$Script:DesignerModuleName' module is not installed. "
-            "The 'PowerShell DSC resource modules' Pester Tests in Meta.Tests.ps1 "
-            'will fail until this module is installed.'
-            ) -Join '' )
-    }
-}
-
-<#
-    .SYNOPSIS
         Will attempt to download the xDSCResourceDesignerModule code via
-        PowerShellGet or Nuget package. If already installed will return
-        without making any changes.
+        PowerShellGet or Nuget package and return the module.
+        
+        If already installed will return the module without making changes.
+
+        If module could not be downloaded it will return null.
     
     .PARAMETER Force
         Used to force any installations to occur without confirming with
@@ -133,6 +99,7 @@ function Import-ResourceDesigner {
 #>
 
 function Install-ResourceDesigner {
+    [OutputType([System.Management.Automation.PSModuleInfo])]
     [CmdletBinding(
         SupportsShouldProcess = $true,
         ConfirmImpact = 'High')]
@@ -148,7 +115,7 @@ function Install-ResourceDesigner {
                 -f $DesignerModule.Version,$Script:DesignerModuleName            
         )
         # Could check for a newer version available here in future and perform an update.
-        return
+        return $DesignerModule
     }
 
     Write-Verbose -Verbose (`
@@ -187,7 +154,7 @@ function Install-ResourceDesigner {
                 '{0} module was not installed automatically.' `
                     -f $Script:DesignerModuleName
             )
-            return
+            return $null
         }
     }
     else
@@ -222,7 +189,7 @@ function Install-ResourceDesigner {
                         'Nuget.exe was not installed. {0} module can not be installed automatically.' `
                             -f $Script:DesignerModuleName
                     )
-                    return        
+                    return $null    
                 }
             }
             else
@@ -263,7 +230,8 @@ function Install-ResourceDesigner {
                 '{0} module was not installed automatically.' `
                     -f $Script:DesignerModuleName
             )
-            return
+            return $null
         }
     }
+    return (Get-Module -Name $Script:DesignerModuleName -ListAvailable)
 }


### PR DESCRIPTION
This should fix Issue #8.

The following changes were made:
1. Code to download xDSCResourceDesigner moved from Meta.Tests.ps1 into Get-ResourceDesigner function of TestHelper.psm1
2. If PowerShellGet module installed: xDSCResourceDesigner downloaded using Install-Module.
3. If PowerShellGet Module not installed: xDSCResourceDesigner install using Nuget.exe.
4. No longer uses Start-Process to call out to Nuget.exe.
5. xDSCResourceDesigner only downloaded automatically when running in AppVeyor.
6. xDSCResourceDesigner Module imported using Name only (not path) so that it works when installed via PowerShellGet.
7. Added some AppVeyor config samples and other details into the Readme.md.

I've thrown this through a lot of tests on projects using both Windows Server 2012 R2 and Unstable AppVeyor build environments and have not run into any failures so far.

Thanks!