### PR TITLE
Modifying Verbose String

### DIFF
--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -132,7 +132,7 @@ function Install-ModuleFromPowerShellGallery {
         # Module is already installed - report it.
         Write-Verbose -Verbose (`
             'Version {0} of the {1} module is already installed.' `
-                -f $module.Version,$moduleName            
+                -f $($module.Version),$moduleName            
         )
         # Could check for a newer version available here in future and perform an update.
         return $module


### PR DESCRIPTION
Install-ModuleFromPowerShellGallery has a verbose string that is coming back as such:
```powershell
VERBOSE: Version System.Object[] of the xDscResourceDesigner module is already installed.
````

This is a modification to correctly come back with the version number as designed.