### PR TITLE
Output PSScriptAnalyzer results correctly when more than one record. Fixes #18

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -136,7 +136,7 @@ try
         if ($PSVersion.Major -ge 5)
         {
             Context 'PSScriptAnalyzer' {
-                It "passes Invoke-ScriptAnalyzer" {
+                It 'passes Invoke-ScriptAnalyzer' {
 
                     # Perform PSScriptAnalyzer scan.
                     # Using ErrorAction SilentlyContinue not to cause it to fail due to parse errors caused by unresolved resources.
@@ -144,8 +144,9 @@ try
                     # Errors will still be returned as expected.
                     $PSScriptAnalyzerErrors = Invoke-ScriptAnalyzer -path $RepoRoot -Severity Error -Recurse -ErrorAction SilentlyContinue
                     if ($PSScriptAnalyzerErrors -ne $null) {
-                        Write-Error "There are PSScriptAnalyzer errors that need to be fixed:`n $PSScriptAnalyzerErrors"
-                        Write-Error "For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/"
+                        Write-Error -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
+                        @($PSScriptAnalyzerErrors).Foreach( { Write-Error -Message $_ } )
+                        Write-Error -Message 'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
                         $PSScriptAnalyzerErrors.Count | Should Be $null
                     }
                 }      

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -144,9 +144,9 @@ try
                     # Errors will still be returned as expected.
                     $PSScriptAnalyzerErrors = Invoke-ScriptAnalyzer -path $RepoRoot -Severity Error -Recurse -ErrorAction SilentlyContinue
                     if ($PSScriptAnalyzerErrors -ne $null) {
-                        Write-Error -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
-                        @($PSScriptAnalyzerErrors).Foreach( { Write-Error -Message $_ } )
-                        Write-Error -Message 'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
+                        Write-Warning -Message 'There are PSScriptAnalyzer errors that need to be fixed:'
+                        @($PSScriptAnalyzerErrors).Foreach( { Write-Warning -Message "$($_.Scriptname) (Line $($_.Line)): $($_.Message)" } )
+                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
                         $PSScriptAnalyzerErrors.Count | Should Be $null
                     }
                 }      


### PR DESCRIPTION
This resolves issue #18.

@vors or @TravisEz13 - could one of you possibly take a look at this while @KarolKaczmarek is away? It is not super critical, but would be nice to get it fixed because at the moment the PSScriptAnalyzer error output isn't visible at all.

This change causes PSScriptAnalyzer output now shows like this:
![2015-12-20_11-28-57](https://cloud.githubusercontent.com/assets/7589164/11915481/e519adb8-a70c-11e5-9a4a-83b93fe77380.png)

I changed all the Write-Error to Write-Warning, because Write-Error causes an exception to be thrown and then control jumps straight to the "Should Be", which skips means that the remaining messages are never output.

Also corrects (due to ISE Steroids warnings):
1. Double quotes changed to single quotes for strings not containing any variables.
