### PR TITLE
Making sure Install-ModuleFromPowerShellGallery returns only one record. Fixes #19

### DIFF
--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -132,10 +132,13 @@ function Install-ModuleFromPowerShellGallery {
         # Module is already installed - report it.
         Write-Host -Object (`
             'Version {0} of the {1} module is already installed.' `
-                -f $($module.Version),$moduleName            
+                -f $($module.Version -join ', '),$moduleName            
         ) -ForegroundColor:Yellow
         # Could check for a newer version available here in future and perform an update.
-        return $module
+        # Return only the latest version of the module
+        return $module `
+            | Sort-Object -Property Version -Descending `
+            | Select-Object -First 1        
     }
 
     Write-Verbose -Message (`


### PR DESCRIPTION
This is a fix to issue #19.

It resolves errors caused when a local testing machine has more than one version of the PSScriptAnalyzer module installed.

Until this is installed, any errors caused by multiple PSScriptAnalyzer modules can be resolved by just removing any older versions of PSScriptAnalyzer. So this is not a critical issue.

Thanks!

