### PR TITLE
Handle DscResource written with Powershell Classes

### DIFF
--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -239,7 +239,7 @@ function Install-ModuleFromPowerShellGallery {
            for testing as well as storing the backed up settings.
            
         The above changes are reverted by calling the Restore-TestEnvironment
-        function. This includes deleteing the temporary working folder.
+        function. This includes deleting the temporary working folder.
     
     .PARAMETER DSCModuleName
         The name of the DSC Module containing the resource that the tests will be
@@ -253,6 +253,11 @@ function Install-ModuleFromPowerShellGallery {
         Specifies the type of tests that are being intialized. It can be:
         Unit: Initialize for running Unit tests on a DSC resource. Default.
         Integration: Initialize for running Integration tests on a DSC resource.
+    
+    .PARAMETER ResourceType
+        Specifies if the DscResource under test is mof-based or class-based. It can be:
+        Mof: The test initialization assumes a Mof-based DscResource folder structure. Default.
+        Class: The test initialization assumes a Class-based DscResource folder structure.
 
     .OUTPUT
         Returns a test environment object which must be passed to the
@@ -286,7 +291,7 @@ function Install-ModuleFromPowerShellGallery {
             
         This command will initialize the test enviroment for Integration testing
         the DSC resource in the xModule DSC module
-        when the module with a Powershell class (different module folder structure)
+        when the module with a Powershell class (class based module folder structure)
 #>
 function Initialize-TestEnvironment
 {
@@ -306,7 +311,6 @@ function Initialize-TestEnvironment
         [ValidateSet('Unit','Integration')]
         [String] $TestType,
 
-        [Parameter(Mandatory=$true)]
         [ValidateSet('Mof','Class')]
         [String] $ResourceType = 'Mof'
 

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -344,8 +344,7 @@ function Initialize-TestEnvironment
     # The folder where this module is found
     [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
     
-    # The folder that all tests will find this module in
-    [string] $modulesFolder = Split-Path -Parent $moduleRoot
+    
         
     # Import the Module
     $Splat = @{
@@ -355,6 +354,9 @@ function Initialize-TestEnvironment
         ErrorAction = 'Stop'
     }
     $DSCModuleFile = Get-Item -Path (Join-Path @Splat)
+
+    # The folder that all tests will find this module in
+    [string] $modulesFolder = Split-Path -Parent (Split-Path -Parent $DSCModuleFile)
     
     # Remove all copies of the module from memory so an old one is not used.
     if (Get-Module -Name $DSCModuleFile.BaseName -All)

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -275,7 +275,18 @@ function Install-ModuleFromPowerShellGallery {
             -TestType Integration
             
         This command will initialize the test enviroment for Integration testing
-        the MSFT_xFirewall DSC resource in the xNetworking DSC module.    
+        the MSFT_xFirewall DSC resource in the xNetworking DSC module.
+        
+    .EXAMPLE
+        $TestEnvironment = Inialize-TestEnvironment `
+            -DSCModuleName 'xModule' `
+            -DSCResourceName 'MSFT_xResource' `
+            -TestType Integration `
+            -ResourceType Class
+            
+        This command will initialize the test enviroment for Integration testing
+        the DSC resource in the xModule DSC module
+        when the module with a Powershell class (different module folder structure)
 #>
 function Initialize-TestEnvironment
 {
@@ -293,7 +304,12 @@ function Initialize-TestEnvironment
 
         [Parameter(Mandatory=$true)]
         [ValidateSet('Unit','Integration')]
-        [String] $TestType
+        [String] $TestType,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Mof','Class')]
+        [String] $ResourceType = 'Mof'
+
     )
     
     Write-Host -Object (`
@@ -305,7 +321,14 @@ function Initialize-TestEnvironment
     }
     else
     {
-        [String] $RelativeModulePath = "$DSCModuleName.psd1"
+        if ($ResourceType -eq 'Mof')
+        {
+            [String] $RelativeModulePath = "$DSCModuleName.psd1"
+        }
+        else
+        {
+            [String] $RelativeModulePath = "DSCResources\$DSCResourceName\$DSCModuleName.psd1"
+        }
     }
 
     # Unique Temp Working Folder - always gets removed on completion


### PR DESCRIPTION
I converted my resource to use a Powershell class and the test could not run.
The folder structure of a Powershell class based module is not the same.
In the case of class based resource, the .psd1 is in the same folder as the psm1. 
This change is tested on my module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/64)
<!-- Reviewable:end -->
