### PR TITLE
Only integration tests will change the Machine PSModulePath - Fixes #55

### DIFF
--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -370,7 +370,11 @@ function Initialize-TestEnvironment
     }
     $NewModulePath = "$modulesFolder;$NewModulePath"
     $env:PSModulePath = $NewModulePath
-    [System.Environment]::SetEnvironmentVariable('PSModulePath',$NewModulePath,[System.EnvironmentVariableTarget]::Machine)
+    if ($TestType -eq 'integration') {
+        # For integration tests we have to set the Machine PSModulePath because otherwise the DSC
+        # LCM won't be able to find the Resource module being tested and may use the wrong one.
+        [System.Environment]::SetEnvironmentVariable('PSModulePath',$NewModulePath,[System.EnvironmentVariableTarget]::Machine)
+    }
 
     # Preserve and set the execution policy so that the DSC MOF can be created
     $OldExecutionPolicy = Get-ExecutionPolicy
@@ -432,7 +436,10 @@ function Restore-TestEnvironment
     if ($TestEnvironment.OldModulePath -ne $env:PSModulePath)
     {
         $env:PSModulePath = $TestEnvironment.OldModulePath
-        [System.Environment]::SetEnvironmentVariable('PSModulePath',$env:PSModulePath,[System.EnvironmentVariableTarget]::Machine)
+        if ($TestType -eq 'integration') {
+            # Restore the machine PSModulePath for integration tests.
+            [System.Environment]::SetEnvironmentVariable('PSModulePath',$env:PSModulePath,[System.EnvironmentVariableTarget]::Machine)
+        }
     }
 
     # Restore the Execution Policy


### PR DESCRIPTION
This changes the Initialize-TestEnvironmet and Restore-TestEnvironment so that the Machine level Environment variable for PSModulePath is set only when executing Integration tests. Unit tests will only set the process level PSModulePath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/67)
<!-- Reviewable:end -->
