### PR TITLE
Allow initialization and restoration of test environments for unprivileged users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 * Removed code to Remove-Module from Initialize-TestEnvironment because not required: Import-Module -force should do the same thing.
 * Initialize-TestEnvironment changed to import module being tested into Global scope so that InModuleScope not required in tests.
 * Fixed aliases in files
+* Initialize-TestEnvironment changed to update the execution policy for the current process only
+* Restore-TestEnvironment changed to update the execution policy for the current process only.
 
 ### 0.2.0.0
 * Fixed unicode and path bugs in tests

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -384,7 +384,7 @@ function Initialize-TestEnvironment
     $OldExecutionPolicy = Get-ExecutionPolicy
     if ($OldExecutionPolicy -ne 'Unrestricted')
     {
-        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
+        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -Force
     }
 
     # Generate the test environment object that will be returned
@@ -456,7 +456,7 @@ function Restore-TestEnvironment
     # Restore the Execution Policy
     if ($TestEnvironment.OldExecutionPolicy -ne (Get-ExecutionPolicy))
     {
-        Set-ExecutionPolicy -ExecutionPolicy $TestEnvironment.OldExecutionPolicy -Force
+        Set-ExecutionPolicy -ExecutionPolicy $TestEnvironment.OldExecutionPolicy -Scope Process -Force
     }
 
     # Cleanup Working Folder


### PR DESCRIPTION
When calling the `Initialize-TestEnvironment` function as an unprivileged user, the following exception is thrown when by `Set-ExecutionPolicy`: 

`UnauthorizedAccessException: Access to the registry key 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell' is denied.`

Unprivileged users do not have the rights to modify the execution policy globally for the system. I changed the calls to `Set-ExecutionPolicy` to limit the scope of the change to the current process.

`Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -Force`

This change was required in both `Initialize-TestEnvironment` and `Restore-TestEnvironment`.