### PR TITLE
Added test function for Class based resources and adjusted test logic…

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -202,7 +202,7 @@ try
                         {
                             Write-Output -InputObject $_
                         }
-                        elseif (Test-ClassResource -fileName $_.FullName)
+                        elseif (Test-ClassResource -Path $_.FullName)
                         {
                             Write-Output -InputObject $_
                         }
@@ -248,7 +248,7 @@ try
 
             foreach ($psm1file in $psm1Files) 
             {
-                if (-not (Test-ClassResource -fileName $psm1file.FullName)) {
+                if (-not (Test-ClassResource -Path $psm1file.FullName)) {
                     Context "Schema Validation of $($psm1file.BaseName)" {
 
                         It 'should pass Test-xDscResource' {

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -202,6 +202,10 @@ try
                         {
                             Write-Output -InputObject $_
                         }
+                        elseif (Test-ClassResource -fileName $_.FullName)
+                        {
+                            Write-Output -InputObject $_
+                        }
                     }
                 }
         )
@@ -244,20 +248,22 @@ try
 
             foreach ($psm1file in $psm1Files) 
             {
-                Context "Schema Validation of $($psm1file.BaseName)" {
+                if (-not (Test-ClassResource -fileName $psm1file.FullName)) {
+                    Context "Schema Validation of $($psm1file.BaseName)" {
 
-                    It 'should pass Test-xDscResource' {
-                        $result = Test-xDscResource -Name $psm1file.DirectoryName
-                        $result | Should Be $true
-                    }
-
-                    It 'should pass Test-xDscSchema' {
-                        $Splat = @{
-                            Path = $psm1file.DirectoryName
-                            ChildPath = "$($psm1file.BaseName).schema.mof"
+                        It 'should pass Test-xDscResource' {
+                            $result = Test-xDscResource -Name $psm1file.DirectoryName
+                            $result | Should Be $true
                         }
-                        $result = Test-xDscSchema -Path (Join-Path @Splat -Resolve -ErrorAction Stop)
-                        $result | Should Be $true
+
+                        It 'should pass Test-xDscSchema' {
+                            $Splat = @{
+                                Path = $psm1file.DirectoryName
+                                ChildPath = "$($psm1file.BaseName).schema.mof"
+                            }
+                            $result = Test-xDscSchema -Path (Join-Path @Splat -Resolve -ErrorAction Stop)
+                            $result | Should Be $true
+                        }
                     }
                 }
             }

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -505,3 +505,41 @@ function Reset-DSC
     Remove-DscConfigurationDocument -Stage Previous -Force
 }
 
+<#
+    .SYNOPSIS
+        Test if a PowerShell module (psm1) file contains DSC Class
+        Resources.
+
+    .PARAMETER fileName
+        This is the full path of the psm1 file.
+
+    .EXAMPLE
+        Test-ClassResource -fileName 'c:\mymodule\myclassmodule.psm1'
+
+        This command will test myclassmodule for the presence of Class
+        based DSC resources
+#>
+function Test-ClassResource
+{
+    param(
+        [Parameter(ValueFromPipeline=$True,Mandatory=$True)]
+        [string]$fileName
+    )
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($fileName, [ref]$null, [ref]$null)
+
+    $result = foreach ($item in $ast.FindAll({$args[0] -is [System.Management.Automation.Language.AttributeAst]}, $false))
+    {
+        if ($item.Extent.Text -eq '[DscResource()]')
+        {
+            $true
+        }
+    }
+    if ($result)
+    {
+        $true
+    }
+    else
+    {
+        $false
+    }
+}

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -510,11 +510,11 @@ function Reset-DSC
         Test if a PowerShell module (psm1) file contains DSC Class
         Resources.
 
-    .PARAMETER fileName
+    .PARAMETER Path
         This is the full path of the psm1 file.
 
     .EXAMPLE
-        Test-ClassResource -fileName 'c:\mymodule\myclassmodule.psm1'
+        Test-ClassResource -Path 'c:\mymodule\myclassmodule.psm1'
 
         This command will test myclassmodule for the presence of Class
         based DSC resources
@@ -523,8 +523,8 @@ function Test-ClassResource
 {
     param
     (
-        [Parameter(ValueFromPipeline=$True, Mandatory=$True)]
-        [string] $Path
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [String] $Path
     )
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
     $result = $false

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -521,25 +521,19 @@ function Reset-DSC
 #>
 function Test-ClassResource
 {
-    param(
-        [Parameter(ValueFromPipeline=$True,Mandatory=$True)]
-        [string]$fileName
+    param
+    (
+        [Parameter(ValueFromPipeline=$True, Mandatory=$True)]
+        [string] $Path
     )
-    $ast = [System.Management.Automation.Language.Parser]::ParseFile($fileName, [ref]$null, [ref]$null)
-
-    $result = foreach ($item in $ast.FindAll({$args[0] -is [System.Management.Automation.Language.AttributeAst]}, $false))
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+    $result = $false
+    foreach ($item in $ast.FindAll({$args[0] -is [System.Management.Automation.Language.AttributeAst]}, $false))
     {
         if ($item.Extent.Text -eq '[DscResource()]')
         {
-            $true
+            $result = $true
         }
     }
-    if ($result)
-    {
-        $true
-    }
-    else
-    {
-        $false
-    }
+    return $result
 }


### PR DESCRIPTION
… appropriately

This will test the psm1 file containing Class based resources for parse errors but skips the schema check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/75)
<!-- Reviewable:end -->
