### PR TITLE
Added additional tests to deal with Class resource / Mixed resource modules

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -226,7 +226,7 @@ try
                 #Mixed module
                 $MinimumPSVersion = [Version]'5.1'
             }
-            elseif ($null -ne $ClassResource)
+            elseif ($ClassResource)
             {
                 $MinimumPSVersion = [Version]'5.0'
             }

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -538,6 +538,18 @@ function Test-ClassResource
     return $result
 }
 
+<#
+    .SYNOPSIS
+        Get DSC Class resource names from a PowerShell module (psm1) file.
+
+    .PARAMETER Path
+        This is the full path of the psm1 file.
+
+    .EXAMPLE
+        Get-ClassResource -Path 'c:\mymodule\myclassmodule.psm1'
+
+        This command will get DSC Class resource names from the myclassmodule module.
+#>
 function Get-ClassResource
 {
     param

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -537,3 +537,24 @@ function Test-ClassResource
     }
     return $result
 }
+
+function Get-ClassResource
+{
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [String] $Path
+    )
+    if (Test-ClassResource -Path $Path)
+    {
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+        $Result = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.TypeDefinitionAst]}, $false)
+        foreach ($Item in $Result)
+        {
+            if ($Item.Attributes.TypeName.Name -eq 'DscResource')
+            {
+                $Item.Name
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added function to detect Class resource name from psm1 files
- Added test to validate minimum PowerShell version specified in Root Module manifest (4, 5 or 5.1)
- Added test to validate Class resources exported in Root Module manifest
- Added test to validate Class resource modules are specified as nested modules in Root Module manifest

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/76)

<!-- Reviewable:end -->
