### PR TITLE
Clean common tests and modules and add tests for PS Script Analyzer

### DIFF
--- a/MetaFixers.psm1
+++ b/MetaFixers.psm1
@@ -1,115 +1,96 @@
 <#
-    This module helps fix problems, found by Meta.Tests.ps1
+    .SYNOPSIS
+        Fixes problems found by Meta.Tests.ps1
 #>
 
-$ErrorActionPreference = 'stop'
-Set-StrictMode -Version latest
+$errorActionPreference = 'Stop'
+Set-StrictMode -Version 'Latest'
 
-function ConvertTo-UTF8()
+$testHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath 'TestHelper.psm1'
+Import-Module -Name $testHelperModulePath
+
+<#
+    .SYNOPSIS
+        Converts the given file to UTF8 encoding.
+
+    .PARAMETER FileInfo
+        The file to convert.
+#>
+function ConvertTo-UTF8
 {
     [CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
-        [System.IO.FileInfo]$fileInfo
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [System.IO.FileInfo]
+        $FileInfo
     )
 
-    process 
-    {
-        $content = Get-Content -Raw -Encoding Unicode -Path $fileInfo.FullName
-        [System.IO.File]::WriteAllText($fileInfo.FullName, $content, [System.Text.Encoding]::UTF8)
-    }
+    $fileContent = Get-Content -Path $FileInfo.FullName -Encoding 'Unicode' -Raw
+    [System.IO.File]::WriteAllText($FileInfo.FullName, $fileContent, [System.Text.Encoding]::UTF8)
 }
 
-function ConvertTo-ASCII()
+<#
+    .SYNOPSIS
+        Converts the given file to ASCII encoding.
+
+    .PARAMETER FileInfo
+        The file to convert.
+#>
+function ConvertTo-ASCII
 {
     [CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
-        [System.IO.FileInfo]$fileInfo
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [System.IO.FileInfo]
+        $FileInfo
     )
 
-    process 
-    {
-        $content = Get-Content -Raw -Encoding Unicode -Path $fileInfo.FullName
-        [System.IO.File]::WriteAllText($fileInfo.FullName, $content, [System.Text.Encoding]::ASCII)
-    }
+    $fileContent = Get-Content -Path $FileInfo.FullName -Encoding 'Unicode' -Raw
+    [System.IO.File]::WriteAllText($FileInfo.FullName, $fileContent, [System.Text.Encoding]::ASCII)
 }
 
-function ConvertTo-SpaceIndentation()
+function Convert-TabsToSpaceIndentation
 {
     [CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
-        [System.IO.FileInfo]$fileInfo
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [System.IO.FileInfo]
+        $FileInfo
     )
 
-    process 
-    {
-        $content = (Get-Content -Raw -Path $fileInfo.FullName) -replace "`t",'    '
-        [System.IO.File]::WriteAllText($fileInfo.FullName, $content)
-    }
+    $fileContent = Get-Content -Path $FileInfo.FullName -Encoding 'Unicode' -Raw
+    $newFileContent = $fileContent.Replace("`t", '    ')
+    [System.IO.File]::WriteAllText($FileInfo.FullName, $newFileContent)
 }
 
-function Get-TextFilesList
+function Get-UnicodeFilesList
 {
+    [OutputType([System.IO.FileInfo[]])]
     [CmdletBinding()]
-    [OutputType([System.IO.FileInfo])]
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$root
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Root
     )
-    Get-ChildItem -File -Recurse $root | Where-Object { @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') -contains $_.Extension } 
+
+    return Get-TextFilesList -Root $Root | Where-Object { Test-FileInUnicode $_ }
 }
 
-function Test-FileUnicode
-{
-    
-    [CmdletBinding()]
-    [OutputType([bool])]
-    param(
-        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
-        [System.IO.FileInfo]$fileInfo
-    )
-
-    process 
-    {
-
-        $path = $fileInfo.FullName
-        $bytes = [System.IO.File]::ReadAllBytes($path)
-        $zeroBytes = @($bytes -eq 0)
-        return [bool]$zeroBytes.Length
-
-    }
-}
-
-function Get-UnicodeFilesList()
+function Add-NewLineAtEndOfFile
 {
     [CmdletBinding()]
-    [OutputType([System.IO.FileInfo])]
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$root
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [System.IO.FileInfo]
+        $FileInfo
     )
 
-    Get-TextFilesList $root | Where-Object { Test-FileUnicode $_ }
-}
-
-function Add-NewLine()
-{
-    [CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
-        [System.IO.FileInfo]$fileInfo
-    )
-
-    process 
-    {
-        $content = Get-Content -Raw -Path $fileInfo.FullName
-        $content += "`r`n"
-        [System.IO.File]::WriteAllText($fileInfo.FullName, $content)
-    }
+    $fileContent = Get-Content -Path $FileInfo.FullName -Raw
+    $fileContent += "`r`n"
+    [System.IO.File]::WriteAllText($FileInfo.FullName, $fileContent)
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 * Fixed aliases in files
 * Initialize-TestEnvironment changed to update the execution policy for the current process only
 * Restore-TestEnvironment changed to update the execution policy for the current process only.
+* Cleaned all common tests
+    * Added tests for PS Script Analyzer
+* Cleaned TestHelper
+    * Removed Force parameter from Install-ModuleFromPowerShellGallery
+    * Added more test helper functions
+* Cleaned MetaFixers and TestRunner
 
 ### 0.2.0.0
 * Fixed unicode and path bugs in tests


### PR DESCRIPTION
There was a test break in PSDscResources due to a bad function call (Test-ModuleManifest) in one of the common tests.

While I was fixing that test, I also cleaned up all the other common tests along with the other modules provided in this repo.

I also added some new tests to check for PS Script Analyzer DSC Resource Kit required/flagged rules as well as rule suppressions of required rules.
3 of these tests (the ones that check for required, flagged, and other error rules) currently pass automatically, but they will print out warnings in AppVeyor. The automatic passes are in place to give people time to fix the errors coming from those tests before we turn them on sometime around the beginning of 2017 (Jan-Feb).

One of the biggest changes here is that I have removed the 'Working Directory' from the test environment. If a module is using this, it will need to be updated to use Pester's $TestDrive should be used instead.

`Install-ModuleFromPowerShellGallery` has also been modified. It only seems to be called outside this module in xNetworking's IntegrationHelper.ps1 file. I will submit a PR for that repo shortly if needed.

To all module maintainers (@athaynes, @BrianFarnhill, @PlagueHO,  @mhendric, @tysonjhayes, @johlju), this PR contains large updates to the common tests which may affect PRs in your repos. Please let me know ASAP if any problems arise.

@mbreakey3 Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/79)
<!-- Reviewable:end -->
