### PR TITLE
Adding files to the text file extensions list.

### DIFF
--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -642,7 +642,7 @@ function Get-TextFilesList
         $Root
     )
 
-    $textFileExtensions = @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof')
+    $textFileExtensions = @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof','.md','.js','.yml')
 
     return Get-ChildItem -Path $Root -File -Recurse | Where-Object { $textFileExtensions -contains $_.Extension }
 }


### PR DESCRIPTION
Found use cases where I forgot to add line breaks at the end of a few files.  Adding in handling for those to capture the failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/83)
<!-- Reviewable:end -->
