### PR TITLE
Fix Detection of Repo Root folder in Meta.tests.ps1 - Fixes #96

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -16,9 +16,9 @@ $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'Ds
 $repoRootPath = $moduleRootFilePath
 $repoRootPathFound = $false
 while (-not $repoRootPathFound `
-    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent -Force))))
+    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent))))
 {
-    if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory)
+    if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory -Force)
     {
         $repoRootPathFound = $true
         break

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -16,7 +16,7 @@ $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'Ds
 $repoRootPath = $moduleRootFilePath
 $repoRootPathFound = $false
 while (-not $repoRootPathFound `
-    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent))))
+    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent -Force))))
 {
     if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory)
     {


### PR DESCRIPTION
This PR fixes #96 so that the markdown test correctly scan all markdowns in xNetworking and SharePointDsc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/97)
<!-- Reviewable:end -->
