### PR TITLE
Update AppVeyor.psm1

### DIFF
--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -28,12 +28,17 @@ else
         3. Installs the Pester PowerShell Module.
         4. Executes Invoke-CustomAppveyorInstallTask if defined in .AppVeyor\CustomAppVeyorTasks.psm1
            in resource module repository.
+           
+    .EXAMPLE
+        Invoke-AppveyorInstallTask -PesterMaximumVersion 3.4.3
 #>
 function Invoke-AppveyorInstallTask
 {
     [CmdletBinding(DefaultParametersetName='Default')]
     param
     (
+        [Version]
+        $PesterMaximumVersion
     )
 
     # Load the test helper module
@@ -48,7 +53,14 @@ function Invoke-AppveyorInstallTask
                               -ChildPath 'nuget.exe'
     Install-NugetExe -OutFile $nugetExePath
 
-    Install-Module -Name Pester -Force
+    if ($PesterMaximumVersion)
+    {
+        Install-Module -Name Pester -MaximumVersion $PesterMaximumVersion -Force
+    }
+    else
+    {
+        Install-Module -Name Pester -Force
+    }
 
     # Execute the custom install task if defined
     if ($customTaskModuleLoaded `


### PR DESCRIPTION
* Modifying Invoke-AppveyorInstallTask to accept a Maximum Pester Version.
* Adding example of use of new parameter.

Currently this is a requirement in xWebAdministration due to how the latest version of Pester handles some comparisons. I believe our bug should be fixed in later versions but this is handy for when we run into situations such as this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/111)
<!-- Reviewable:end -->
