### PR TITLE
Fix Error Message when NPM not available but Markdown tests enabled - Fixes #112

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -16,9 +16,9 @@ $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'Ds
 $repoRootPath = $moduleRootFilePath
 $repoRootPathFound = $false
 while (-not $repoRootPathFound `
-    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent -Force))))
+    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent))))
 {
-    if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory)
+    if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory -Force)
     {
         $repoRootPathFound = $true
         break

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -16,7 +16,7 @@ $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'Ds
 $repoRootPath = $moduleRootFilePath
 $repoRootPathFound = $false
 while (-not $repoRootPathFound `
-    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent))))
+    -and -not ([String]::IsNullOrEmpty((Split-Path -Path $repoRootPath -Parent -Force))))
 {
     if (Get-ChildItem -Path $repoRootPath -Filter '.git' -Directory)
     {

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -58,7 +58,8 @@ Describe 'Common Tests - File Formatting' {
 
         foreach ($textFile in $textFiles)
         {
-            if (Test-FileInUnicode $textFile) {
+            if (Test-FileInUnicode $textFile)
+            {
                 if($textFile.Extension -ieq '.mof')
                 {
                     Write-Warning -Message "File $($textFile.FullName) should be converted to ASCII. Use fixer function 'Get-UnicodeFilesList `$pwd | ConvertTo-ASCII'."
@@ -308,7 +309,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                 It 'Should pass all error-level PS Script Analyzer rules' {
                     $errorPssaRulesOutput = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters -Severity 'Error'
 
-                    if ($null -ne $errorPssaRulesOutput) {
+                    if ($null -ne $errorPssaRulesOutput)
+                    {
                         Write-Warning -Message 'Error-level PSSA rule(s) did not pass.'
                         Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
 
@@ -326,7 +328,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                 It 'Should pass all required PS Script Analyzer rules' {
                     $requiredPssaRulesOutput = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters -IncludeRule $requiredPssaRuleNames
 
-                    if ($null -ne $requiredPssaRulesOutput) {
+                    if ($null -ne $requiredPssaRulesOutput)
+                    {
                         Write-Warning -Message 'Required PSSA rule(s) did not pass.'
                         Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
 
@@ -349,7 +352,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                 It 'Should pass all flagged PS Script Analyzer rules' {
                     $flaggedPssaRulesOutput = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters -IncludeRule $flaggedPssaRuleNames
 
-                    if ($null -ne $flaggedPssaRulesOutput) {
+                    if ($null -ne $flaggedPssaRulesOutput)
+                    {
                         Write-Warning -Message 'Flagged PSSA rule(s) did not pass.'
                         Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed or approved to be suppressed:'
 
@@ -374,7 +378,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     $newErrorPssaRulesOutput = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters -ExcludeRule $knownPssaRuleNames -Severity 'Error'
 
-                    if ($null -ne $newErrorPssaRulesOutput) {
+                    if ($null -ne $newErrorPssaRulesOutput)
+                    {
                         Write-Warning -Message 'Recently-added, error-level PSSA rule(s) did not pass.'
                         Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed or approved to be suppressed:'
 
@@ -438,7 +443,8 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         }
 
         $exampleFiles = Get-ChildItem -Path (Join-Path -Path $moduleRootFilePath -ChildPath 'Examples') -Filter "*.ps1" -Recurse
-        foreach ($exampleFile in $exampleFiles) {
+        foreach ($exampleFile in $exampleFiles)
+        {
             Context -Name $exampleFile.Name {
 
                 try
@@ -510,12 +516,12 @@ Describe 'Common Tests - Validate Markdown Files' -Tag 'Markdown' {
             try
             {
                 Start-Process -FilePath "gulp" -ArgumentList @(
-                        'test-mdsyntax',
-                        '--silent',
-                        '--rootpath',
-                        $repoRootPath,
-                        '--dscresourcespath',
-                        $dscResourcesFolderFilePath) `
+                    'test-mdsyntax',
+                    '--silent',
+                    '--rootpath',
+                    $repoRootPath,
+                    '--dscresourcespath',
+                    $dscResourcesFolderFilePath) `
                     -Wait -WorkingDirectory $PSScriptRoot -PassThru -NoNewWindow
                 Start-Sleep -Seconds 3
                 $mdIssuesPath = Join-Path -Path $PSScriptRoot -ChildPath "markdownissues.txt"
@@ -530,6 +536,7 @@ Describe 'Common Tests - Validate Markdown Files' -Tag 'Markdown' {
                         }
                     }
                 }
+                Remove-Item -Path $mdIssuesPath -Force -ErrorAction SilentlyContinue
             }
             catch [System.Exception]
             {
@@ -538,7 +545,6 @@ Describe 'Common Tests - Validate Markdown Files' -Tag 'Markdown' {
                                         "run 'npm install -g gulp' in order to have this " + `
                                         "text execute.")
             }
-            Remove-Item -Path $mdIssuesPath -Force -ErrorAction SilentlyContinue
             if($optin)
             {
                 $mdErrors | Should Be 0


### PR DESCRIPTION
This PR fixes the error occurring when trying to remove the Markdown results file when it doesn't exist.

This also corrects the code style to meet the standard guidelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/113)
<!-- Reviewable:end -->
