### PR TITLE
Fix to ignore node_modules path in build

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -446,10 +446,13 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         {
             $powershellModulePath = Join-Path -Path (Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\Modules') -ChildPath $repoName
 
-            Get-ChildItem -Path $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
+            $items =  Get-ChildItem -Path $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
                 $_.FullName -notmatch "node_modules"
-            } | Copy-Item -Destination {
-                Join-Path -Path $powershellModulePath -ChildPath $_.FullName.Substring($env:APPVEYOR_BUILD_FOLDER.length)
+            } 
+            
+            $items | Copy-Item -Destination {
+                Join-Path -Path $powershellModulePath `
+                          -ChildPath $_.FullName.Substring($env:APPVEYOR_BUILD_FOLDER.length)
             }
         }
 

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -446,7 +446,7 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         {
             $powershellModulePath = Join-Path -Path (Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\Modules') -ChildPath $repoName
 
-            Get-ChildItem $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
+            Get-ChildItem -Path $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
                 $_.FullName -notmatch "node_modules"
             } | Copy-Item -Destination {
                 Join-Path -Path $powershellModulePath -ChildPath $_.FullName.Substring($env:APPVEYOR_BUILD_FOLDER.length)

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -446,15 +446,11 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         {
             $powershellModulePath = Join-Path -Path (Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\Modules') -ChildPath $repoName
 
-            Write-Verbose -Message "Copying from: $env:APPVEYOR_BUILD_FOLDER"
-            Write-Verbose -Message "Copying to: $powershellModulePath"
-
-            Get-ChildItem $env:APPVEYOR_BUILD_FOLDER -Recurse | ForEach-Object {
-                if ($_.FullName.Length -gt 240) {
-                    Write-Warning -Message "Long file: $($_.FullName)" 
-                }
+            Get-ChildItem $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
+                $_.FullName -notmatch "node_modules"
+            } | Copy-Item -Destination {
+                Join-Path -Path $powershellModulePath -ChildPath $_.FullName.Substring($env:APPVEYOR_BUILD_FOLDER.length)
             }
-            Copy-item -Path $env:APPVEYOR_BUILD_FOLDER -Destination $powershellModulePath -Recurse -Force
         }
 
         $exampleFile = Get-ChildItem -Path (Join-Path -Path $moduleRootFilePath -ChildPath 'Examples') -Filter '*.ps1' -Recurse

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -449,7 +449,7 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
             Write-Verbose -Message "Copying from: $env:APPVEYOR_BUILD_FOLDER"
             Write-Verbose -Message "Copying to: $powershellModulePath"
 
-            Get-ChildItem C:\repos\OfficeOnlineServerDsc\ -Recurse | ForEach-Object {
+            Get-ChildItem $env:APPVEYOR_BUILD_FOLDER -Recurse | ForEach-Object {
                 if ($_.FullName.Length -gt 240) {
                     Write-Warning -Message "Long file: $($_.FullName)" 
                 }

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -446,6 +446,14 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         {
             $powershellModulePath = Join-Path -Path (Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\Modules') -ChildPath $repoName
 
+            Write-Verbose -Message "Copying from: $env:APPVEYOR_BUILD_FOLDER"
+            Write-Verbose -Message "Copying to: $powershellModulePath"
+
+            Get-ChildItem C:\repos\OfficeOnlineServerDsc\ -Recurse | ForEach-Object {
+                if ($_.FullName.Length -gt 240) {
+                    Write-Warning -Message "Long file: $($_.FullName)" 
+                }
+            }
             Copy-item -Path $env:APPVEYOR_BUILD_FOLDER -Destination $powershellModulePath -Recurse -Force
         }
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ Invoke-AppveyorAfterTestTask `
 * Fixed Wiki Generation when Example header contains parentheses.
 * Added so that any error message for each test are also published to the AppVeyor "Tests-view".
 * Added a common test to verify so that no markdown files contains Byte Order Mark (BOM) (issue #108).
+* Fixed bug where node_modules directory caused errors with long file paths for
+  tests
 
 ### 0.2.0.0
 


### PR DESCRIPTION
I recently came across a bug that was being causes by long file paths in the "node_modules" path when the AppVeyor builds were copying the module to the system modules directory - it would throw the PathTooLongException. To avoid this I've made a small update here to get it to ignore the node_modules folder as it shouldn't be needed here anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/134)
<!-- Reviewable:end -->
