### PR TITLE
AppVeyor: Added failure message to be published to "Tests-view" - Fixes #138

### DIFF
--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -148,7 +148,7 @@ function Invoke-AppveyorTestScriptTask
 
         [Parameter()]
         [Switch]
-        $DisableConsistency 
+        $DisableConsistency
     )
 
     # Convert the Main Module path into an absolute path if it is relative
@@ -175,13 +175,13 @@ function Invoke-AppveyorTestScriptTask
         $disableConsistencyMofPath = Join-Path -Path $env:temp -ChildPath 'DisableConsistency'
         if ( -not (Test-Path -Path $disableConsistencyMofPath))
         {
-            $null = New-Item -Path $disableConsistencyMofPath -ItemType Directory -Force 
+            $null = New-Item -Path $disableConsistencyMofPath -ItemType Directory -Force
         }
 
         # have LCM Apply only once.
         Configuration Meta
         {
-            LocalConfigurationManager 
+            LocalConfigurationManager
             {
                 ConfigurationMode = 'ApplyOnly'
             }
@@ -189,7 +189,7 @@ function Invoke-AppveyorTestScriptTask
         meta -outputPath $disableConsistencyMofPath
 
         Set-DscLocalConfigurationManager -Path $disableConsistencyMofPath -Force -Verbose
-        $null = Remove-Item -LiteralPath $disableConsistencyMofPath -Recurse -Force -Confirm:$false 
+        $null = Remove-Item -LiteralPath $disableConsistencyMofPath -Recurse -Force -Confirm:$false
     }
 
     switch ($Type)
@@ -261,12 +261,23 @@ function Invoke-AppveyorTestScriptTask
             }
         }
 
-        Add-AppveyorTest `
-            -Name $result.Name `
-            -Framework NUnit `
-            -Filename $componentName `
-            -Outcome $appVeyorResult `
-            -Duration $result.Time.TotalMilliseconds
+        $addAppVeyorTestParameters = @{
+            Name = $result.Name
+            Framework = 'NUnit'
+            Filename = $componentName
+            Outcome = $appVeyorResult
+            Duration = $result.Time.TotalMilliseconds
+        }
+
+        if ($result.FailureMessage)
+        {
+            $addAppVeyorTestParameters += @{
+                ErrorMessage = $result.FailureMessage
+                ErrorStackTrace = $result.StackTrace
+            }
+        }
+
+        Add-AppveyorTest @addAppVeyorTestParameters
     }
 
     Push-TestArtifact -Path $testResultsFile

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Invoke-AppveyorAfterTestTask `
 * Fixed Wiki Generation to create Markdown that does not violate markdown rules
 * Removed violation of markdown rules from Readme.md
 * Fixed Wiki Generation when Example header contains parentheses.
+* Added so that any error message for each test are also published to the AppVeyor "Tests-view".
 
 ### 0.2.0.0
 


### PR DESCRIPTION
- Changes to AppVeyor
  -  Added so that any error message for each test are also published to the AppVeyor "Tests-view".

There was some spaces that was removed as well when I saved the file in VS Code (have auto-trim enabled). So there are a few rows that was changes because of that.

This branch was used to mock fails: 
https://github.com/johlju/xSQLServer/tree/appveyor-test

Test run here and example in screenshot:
https://ci.appveyor.com/project/johlju/xsqlserver/build/5.0.558.0/tests

![image](https://cloud.githubusercontent.com/assets/7189721/25578930/736e90ee-2e73-11e7-9ad0-d436e475c49d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/137)
<!-- Reviewable:end -->
