### PR TITLE
Added a common test to verify so that no markdown files contains BOM - Fixes #108

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -139,6 +139,28 @@ Describe 'Common Tests - File Formatting' {
 
         $containsFileWithoutNewLine | Should Be $false
     }
+
+    Context 'When repository contains markdown files' {
+        $markdownFileExtensions = @('.md')
+
+        $markdownFiles = $textFiles |
+                            Where-Object { $markdownFileExtensions -contains $_.Extension }
+
+        foreach ($markdownFile in $markdownFiles)
+        {
+            It ('Markdown file ''{0}'' should not have Byte Order Mark (BOM)' -f $markdownFile.Name) {
+                # This reads the first three bytes of the first row.
+                $firstThreeBytes = Get-Content -Path $markdownFile.FullName -Encoding Byte -ReadCount 3 -TotalCount 3
+
+                # Check for the correct byte order (239,187,191) which equal the Byte Order Mark (BOM).
+                $markdownFileHasBom = ($firstThreeBytes[0] -eq 239 `
+                    -and $firstThreeBytes[1] -eq 187 `
+                    -and $firstThreeBytes[2] -eq 191)
+
+                $markdownFileHasBom | Should Be $false
+            }
+        }
+    }
 }
 
 Describe 'Common Tests - .psm1 File Parsing' {

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -157,6 +157,10 @@ Describe 'Common Tests - File Formatting' {
                     -and $firstThreeBytes[1] -eq 187 `
                     -and $firstThreeBytes[2] -eq 191)
 
+                if ($markdownFileHasBom) {
+                    Write-Warning -Message "$($markdownFile.FullName) contain Byte Order Mark (BOM). Use fixer function 'ConvertTo-ASCII'."
+                }
+
                 $markdownFileHasBom | Should Be $false
             }
         }

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Invoke-AppveyorAfterTestTask `
 * Removed violation of markdown rules from Readme.md
 * Fixed Wiki Generation when Example header contains parentheses.
 * Added so that any error message for each test are also published to the AppVeyor "Tests-view".
+* Added common test to test if markdown files contains Byte Order Mark (BOM) (issue #108).
 
 ### 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Invoke-AppveyorAfterTestTask `
 * Removed violation of markdown rules from Readme.md
 * Fixed Wiki Generation when Example header contains parentheses.
 * Added so that any error message for each test are also published to the AppVeyor "Tests-view".
-* Added common test to test if markdown files contains Byte Order Mark (BOM) (issue #108).
+* Added a common test to verify so that no markdown files contains Byte Order Mark (BOM) (issue #108).
 
 ### 0.2.0.0
 


### PR DESCRIPTION
Added a common test to verify so that no markdown files contains Byte Order Mark (BOM) (issue #108).

Tested here:
https://ci.appveyor.com/project/johlju/xsqlserver/build/5.0.570.0/tests

![image](https://cloud.githubusercontent.com/assets/7189721/25911586/b64087e0-35b4-11e7-8859-b75bf7356e2b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/139)
<!-- Reviewable:end -->
