### PR TITLE
Using module path in PS Core

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -464,7 +464,7 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         <#
             For Appveyor builds copy the module to the system modules directory so it falls in to a PSModulePath folder and is
             picked up correctly.
-            For a user to run the test, they need to make sure that the module exist in one of the paths in env:PSModulePath, i.e.
+            For a user to run the test, they need to make sure that the module exists in one of the paths in env:PSModulePath, i.e.
             '%USERPROFILE%\Documents\WindowsPowerShell\Modules'.
             No copying is done when a user runs the test, because that could potentially be destructive.
         #>

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -464,18 +464,17 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         <#
             For Appveyor builds copy the module to the system modules directory so it falls in to a PSModulePath folder and is
             picked up correctly.
-            For a user to run the test, they need to make sure that the module exist in one of the paths in env:PSModulePath, i.e.
-            '%USERPROFILE%\Documents\WindowsPowerShell\Modules'.
-            No copying is done when a user runs the test, because that could potentially be destructive.
+            For a user to run the test, they need to make sure that the module exist in one of the paths in env:PSModulePath.
+            No copying is done when a user runs the test, becuase that could potentially be destructive.
         #>
         if ($env:APPVEYOR -eq $true)
         {
-            $powershellModulePath = Join-Path -Path (Join-Path -Path $env:SystemRoot -ChildPath 'System32\WindowsPowerShell\v1.0\Modules') -ChildPath $repoName
+            $powershellModulePath = Join-Path -Path (Get-PSModulePathItem -Item PSHome) -ChildPath $repoName
 
             $items =  Get-ChildItem -Path $env:APPVEYOR_BUILD_FOLDER -Recurse | Where-Object -FilterScript {
                 $_.FullName -notmatch "node_modules"
-            }
-
+            } 
+            
             $items | Copy-Item -Destination {
                 Join-Path -Path $powershellModulePath `
                           -ChildPath $_.FullName.Substring($env:APPVEYOR_BUILD_FOLDER.length)

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -464,12 +464,14 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
         <#
             For Appveyor builds copy the module to the system modules directory so it falls in to a PSModulePath folder and is
             picked up correctly.
-            For a user to run the test, they need to make sure that the module exist in one of the paths in env:PSModulePath.
-            No copying is done when a user runs the test, becuase that could potentially be destructive.
+            For a user to run the test, they need to make sure that the module exist in one of the paths in env:PSModulePath, i.e.
+            '%USERPROFILE%\Documents\WindowsPowerShell\Modules'.
+            No copying is done when a user runs the test, because that could potentially be destructive.
         #>
         if ($env:APPVEYOR -eq $true)
         {
-            $powershellModulePath = Join-Path -Path (Get-PSModulePathItem -Item PSHome) -ChildPath $repoName
+            $psHomePSModulePathItem = Get-PSHomePSModulePathItem
+            $powershellModulePath = Join-Path -Path $psHomePSModulePathItem -ChildPath $repoName
 
             Write-Verbose -Message ('Copying module from ''{0}'' to ''{1}''' -f $moduleRootFilePath, $powershellModulePath) -Verbose
 

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -928,6 +928,7 @@ function Get-CommandNameParameterValue
 <#
     .SYNOPSIS
         Returns the requested item in $env:PSModulePath
+            PSHome      - Requests the item under $PSHOME
             UserProfile - Requests the item under $env:USERPROFILE
         
         If multiple items are found, it returns the shortest item.

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -931,7 +931,7 @@ function Get-CommandNameParameterValue
     .SYNOPSIS
         Returns first the item in $env:PSModulePath that matches the given Prefix ($env:PSModulePath is list of semicolon-separated items).
         If no items are found, it reports an error.
-    .PARAMS Prefix
+    .PARAMETER Prefix
         Path prefix to look for.
     .NOTES
         If there are multiple matching items, the function returns the first item that occurs in the module path; this matches the lookup 
@@ -976,7 +976,7 @@ function Get-PSModulePathItem {
 function Get-UserProfilePSModulePathItem {
     param()
 
-    return Get-PSModulePathItem $env:USERPROFILE
+    return Get-PSModulePathItem -Prefix $env:USERPROFILE
 }
 
 <#
@@ -994,7 +994,7 @@ function Get-UserProfilePSModulePathItem {
 function Get-PSHomePSModulePathItem {
     param()
 
-    return Get-PSModulePathItem $global:PSHOME
+    return Get-PSModulePathItem -Prefix $global:PSHOME
 }
 
 Export-ModuleMember -Function @(

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -756,7 +756,8 @@ function Import-PSScriptAnalyzer
     if ($null -eq $psScriptAnalyzerModule)
     {
         Write-Verbose -Message 'Installing PSScriptAnalyzer from the PowerShell Gallery'
-        $psScriptAnalyzerModulePath = "$(Get-PSModulePathItem -Item UserProfile)\PSScriptAnalyzer"
+        $userProfilePSModulePathItem = Get-UserProfilePSModulePathItem
+        $psScriptAnalyzerModulePath = Join-Path -Path userProfilePSModulePathItem -ChildPath PSScriptAnalyzer
         Install-ModuleFromPowerShellGallery -ModuleName 'PSScriptAnalyzer' -DestinationPath $psScriptAnalyzerModulePath
     }
 
@@ -780,7 +781,8 @@ function Import-xDscResourceDesigner
     if ($null -eq $xDscResourceDesignerModule)
     {
         Write-Verbose -Message 'Installing xDscResourceDesigner from the PowerShell Gallery'
-        $xDscResourceDesignerModulePath = "$(Get-PSModulePathItem -Item UserProfile)\xDscResourceDesigner"
+        $userProfilePSModulePathItem = Get-UserProfilePSModulePathItem
+        $xDscResourceDesignerModulePath = Join-Path -Path $userProfilePSModulePathItem -ChildPath xDscResourceDesigner
         Install-ModuleFromPowerShellGallery -ModuleName 'xDscResourceDesigner' -DestinationPath $xDscResourceDesignerModulePath
     }
 
@@ -927,35 +929,72 @@ function Get-CommandNameParameterValue
 
 <#
     .SYNOPSIS
-        Returns the requested item in $env:PSModulePath
-            PSHome      - Requests the item under $PSHOME
-            UserProfile - Requests the item under $env:USERPROFILE
-        
-        If multiple items are found, it returns the shortest item.
+        Returns first the item in $env:PSModulePath that matches the given Prefix ($env:PSModulePath is list of semicolon-separated items).
         If no items are found, it reports an error.
+    .PARAMS Prefix
+        Path prefix to look for.
+    .NOTES
+        If there are multiple matching items, the function returns the first item that occurs in the module path; this matches the lookup 
+        behavior of PowerSHell, which looks at the items in the module path in order of occurrence.
+    .EXAMPLE
+        If $env:PSModulePath is
+            C:\Program Files\WindowsPowerShell\Modules;C:\Users\foo\Documents\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules
+        then 
+            Get-PSModulePathItem C:\Users
+        will return 
+            C:\Users\foo\Documents\WindowsPowerShell\Modules
 #>
 function Get-PSModulePathItem {
     param(
-        [Parameter(Mandatory)]
-        [ValidateSet('PSHome', 'UserProfile')]
-        [string] $Item
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Prefix
     )
 
-    $itemParent = @{
-        PSHome = $PSHOME
-        UserProfile = $env:USERPROFILE
-    }
-
-    $userProfilePSModulePath = $env:PSModulePath.Split(';') | 
-        Where-Object { $_ -like "$($itemParent[$Item])\*" } |
-        Sort-Object -Property Length |
+    $item = $env:PSModulePath.Split(';') | 
+        Where-Object -FilterScript { $_ -like "$Prefix*" } |
         Select-Object -First 1
 
-    if (!$userProfilePSModulePath) {
-        Write-Error "Cannot find the requested item in the PowerShell module path.`n`$env:PSModulePath = $env:PSModulePath"
+    if (!$item) {
+        Write-Error -Message "Cannot find the requested item in the PowerShell module path.`n`$env:PSModulePath = $env:PSModulePath"
     }
 
-    $userProfilePSModulePath
+    return $item
+}
+
+<#
+    .SYNOPSIS
+        Returns the first item in $env:PSModulePath that is a path under $env:USERPROFILE.
+        If no items are found, it reports an error.
+    .EXAMPLE
+        If $env:PSModulePath is
+            C:\Program Files\WindowsPowerShell\Modules;C:\Users\foo\Documents\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules
+        and the current user is 'foo', then 
+            Get-UserProfilePSModulePathItem 
+        will return 
+            C:\Users\foo\Documents\WindowsPowerShell\Modules
+#>
+function Get-UserProfilePSModulePathItem {
+    param()
+
+    return Get-PSModulePathItem $env:USERPROFILE
+}
+
+<#
+    .SYNOPSIS
+        Returns the first item in $env:PSModulePath that is a path under $env:USERPROFILE.
+        If no items are found, it reports an error.
+    .EXAMPLE
+        If $env:PSModulePath is
+            C:\Program Files\WindowsPowerShell\Modules;C:\Users\foo\Documents\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules
+        then 
+            Get-PSHomePSModulePathItem 
+        will return 
+            C:\Windows\system32\WindowsPowerShell\v1.0\Modules
+#>
+function Get-PSHomePSModulePathItem {
+    param()
+
+    return Get-PSModulePathItem $global:PSHOME
 }
 
 Export-ModuleMember -Function @(
@@ -976,5 +1015,7 @@ Export-ModuleMember -Function @(
     'Get-SuppressedPSSARuleNameList',
     'Reset-DSC',
     'Install-NugetExe',
-    'Get-PesterDescribeOptInStatus'
+    'Get-PesterDescribeOptInStatus',
+    'Get-UserProfilePSModulePathItem',
+    'Get-PSHomePSModulePathItem'
 )


### PR DESCRIPTION
On PSCore, the PowerShell paths are under "...\PowerShell\..." instead of "...\WindowsPowerShell\...".

Added Get-PSModulePathItem to handle those differences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/154)
<!-- Reviewable:end -->
