### PR TITLE
Add basic custom PSSA rules support for validating Resource Kit guidelines - Fixes #86

### DIFF
--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psd1
@@ -1,0 +1,108 @@
+﻿@{
+
+# Script module or binary module file associated with this manifest.
+RootModule = 'DscResource.AnalyzerRules.psm1'
+
+# Version number of this module.
+ModuleVersion = '1.0.0.0'
+
+# ID used to uniquely identify this module
+GUID = 'dc0b0d95-5860-4843-a5b9-29d0fceadd63'
+
+# Author of this module
+Author = 'Microsoft Corporation'
+
+# Company or vendor of this module
+CompanyName = 'Microsoft Corporation'
+
+# Copyright statement for this module
+Copyright = '(c) 2017 Microsoft Corporation. All rights reserved.'
+
+# Description of the functionality provided by this module
+Description = 'This module contains script analyzer rules to ensure DSC Resources meets minimum standards and style guidelines defined by the Microsoft DSC Resource Kit.'
+
+# Minimum version of the Windows PowerShell engine required by this module
+PowerShellVersion = '4.0'
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of Microsoft .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+CLRVersion = '4.0'
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = 'Measure*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+PrivateData = @{
+
+    PSData = @{
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        # Tags = @()
+
+        # A URL to the license for this module.
+        # LicenseUri = ''
+
+        # A URL to the main website for this project.
+        # ProjectUri = ''
+
+        # A URL to an icon representing this module.
+        # IconUri = ''
+
+        # ReleaseNotes of this module
+        # ReleaseNotes = ''
+
+    } # End of PSData hashtable
+
+} # End of PrivateData hashtable
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1,0 +1,106 @@
+﻿#Requires -Version 4.0
+
+# Import Localized Data
+Import-LocalizedData -BindingVariable localizedData
+
+<#
+.SYNOPSIS
+    Validates the [Parameter()] attribute for each parameter.
+.DESCRIPTION
+    All parameters in a param block must contain a [Parameter()] attribute
+    and it must bethe first attribute for each parameter and must start with
+    a capital letter P.
+.EXAMPLE
+    Measure-ParameterBlockParameterAttribute -ScriptBlockAst $ScriptBlockAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+.NOTES
+    None
+#>
+function Measure-ParameterBlockParameterAttribute
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $ScriptBlockAst
+    )
+
+    Process
+    {
+        $results = @()
+
+        try
+        {
+            $diagnosticRecordType = 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord'
+
+            $findAllFunctionsFilter = {
+                $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst]
+            }
+
+            $findAllParametersFilter = {
+                $args[0] -is [System.Management.Automation.Language.ParamBlockAst]
+            }
+
+            [System.Management.Automation.Language.Ast[]] $functionsAst = $ScriptBlockAst.FindAll( $findAllFunctionsFilter, $true )
+
+            foreach ($functionAst in $functionsAst)
+            {
+                [System.Management.Automation.Language.Ast[]] $parametersAst = $functionAst.FindAll( $findAllParametersFilter, $true ).Parameters
+                
+                foreach ($parameterAst in $parametersAst)
+                {
+                    if ($parameterAst.Attributes.Typename.FullName -notcontains 'parameter')
+                    {
+                        $results += New-Object `
+                                    -Typename $diagnosticRecordType `
+                                    -ArgumentList @(
+                                        $localizedData.ParameterBlockParameterAttributeMissing, `
+                                        $parameterAst.Extent, `
+                                        $PSCmdlet.MyInvocation.InvocationName, `
+                                        'Warning', `
+                                        $null
+                                    )
+                    }
+                    elseif ($parameterAst.Attributes[0].Typename.FullName -ne 'parameter')
+                    {
+                        $results += New-Object `
+                                    -Typename $diagnosticRecordType `
+                                    -ArgumentList @(
+                                        $localizedData.ParameterBlockParameterAttributeWrongPlace, `
+                                        $parameterAst.Extent, `
+                                        $PSCmdlet.MyInvocation.InvocationName, `
+                                        'Warning',`
+                                        $null
+                                    )
+                    }
+                    elseif ($parameterAst.Attributes[0].Typename.FullName -cne 'Parameter')
+                    {
+                        $results += New-Object `
+                                    -Typename $diagnosticRecordType  `
+                                    -ArgumentList @(
+                                        $localizedData.ParameterBlockParameterAttributeLowerCase, `
+                                        $parameterAst.Extent, `
+                                        $PSCmdlet.MyInvocation.InvocationName, `
+                                        'Warning', `
+                                        $null
+                                    )
+                    } # if
+                } # foreach parameter
+            } # foreach function
+
+            return $results
+        }
+        catch
+        {
+            $PSCmdlet.ThrowTerminatingError($PSItem)
+        }
+    }
+}
+
+Export-ModuleMember -Function Measure*

--- a/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
@@ -1,0 +1,6 @@
+﻿ConvertFrom-StringData @'
+# English strings
+ParameterBlockParameterAttributeMissing    = A [Parameter()] attribute must be the first attribute of each parameter and be on its own line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-parameter-block
+ParameterBlockParameterAttributeLowerCase  = The [Parameter()] attribute must start with an upper case 'P'. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-parameter-block
+ParameterBlockParameterAttributeWrongPlace = The [Parameter()] attribute must be the first attribute of each parameter. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-parameter-block
+'@

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -325,6 +325,8 @@ Describe 'Common Tests - Script Resource Schema Validation' {
     problems before we turn on these tests. These 'automatic passes' should be removed
     along with the first test (which is replaced by the following 3) around Jan-Feb
     2017.
+    Issue #161 has been raised to adddress this:
+    https://github.com/PowerShell/DscResource.Tests/issues/161
 #>
 Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
@@ -387,9 +389,9 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
         foreach ($dscResourcesPsm1File in $dscResourcesPsm1Files)
         {
             $invokeScriptAnalyzerParameters = @{
-                Path = $dscResourcesPsm1File.FullName
-                ErrorAction = 'SilentlyContinue'
-                Recurse = $true
+                Path                = $dscResourcesPsm1File.FullName
+                ErrorAction         = 'SilentlyContinue'
+                Recurse             = $true
             }
 
             Context $dscResourcesPsm1File.Name {
@@ -431,6 +433,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     <#
                         Automatically passing this test since it may break several resource modules at the moment.
                         Automatic pass to be removed Jan-Feb 2017.
+                        Issue #161 has been raised to adddress this:
+                        https://github.com/PowerShell/DscResource.Tests/issues/161
                     #>
                     $requiredPssaRulesOutput = $null
                     $requiredPssaRulesOutput | Should Be $null
@@ -455,6 +459,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     <#
                         Automatically passing this test since it may break several resource modules at the moment.
                         Automatic pass to be removed Jan-Feb 2017.
+                        Issue #161 has been raised to adddress this:
+                        https://github.com/PowerShell/DscResource.Tests/issues/161
                     #>
                     $flaggedPssaRulesOutput = $null
                     $flaggedPssaRulesOutput | Should Be $null
@@ -481,6 +487,8 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     <#
                         Automatically passing this test since it may break several resource modules at the moment.
                         Automatic pass to be removed Jan-Feb 2017.
+                        Issue #161 has been raised to adddress this:
+                        https://github.com/PowerShell/DscResource.Tests/issues/161
                     #>
                     $newErrorPssaRulesOutput = $null
                     $newErrorPssaRulesOutput | Should Be $null
@@ -503,6 +511,35 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     }
 
                     $requiredRuleIsSuppressed | Should Be $false
+                }
+
+                It 'Should pass all custom DSC Resource Kit PSSA rules' {
+                    $customDscResourceAnalyzerRulesPath = Join-Path -Path $PSScriptRoot -ChildPath 'DscResource.AnalyzerRules'
+                    $customPssaRulesOutput = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters `
+                        -CustomRulePath $customDscResourceAnalyzerRulesPath `
+                        -Severity 'Warning'
+
+                    if ($null -ne $customPssaRulesOutput)
+                    {
+                        Write-Warning -Message 'Custom DSC Resource Kit PSSA rule(s) did not pass.'
+                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
+
+                        foreach ($customPssaRuleOutput in $customPssaRulesOutput)
+                        {
+                            Write-Warning -Message "$($customPssaRuleOutput.ScriptName) (Line $($customPssaRuleOutput.Line)): $($customPssaRuleOutput.Message)"
+                        }
+
+                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                    }
+
+                    <#
+                        Automatically passing this test since it may break several resource modules at the moment.
+                        Automatic pass to be removed Jan-Feb 2017.
+                        Issue #161 has been raised to adddress this:
+                        https://github.com/PowerShell/DscResource.Tests/issues/161
+                    #>
+                    $customPssaRulesOutput = $null
+                    $customPssaRulesOutput | Should Be $null
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -387,6 +387,9 @@ Invoke-AppveyorAfterTestTask `
 * Added new common test so that script files (.ps1) are checked for Byte Order
   Mark (BOM) ([issue #160](https://github.com/PowerShell/DscResource.Tests/issues/160)).
   This test is opt-in using .MetaTestOptIn.json.
+* Added minimum viable product for applying custom PSSA rules to check adherence to
+  DSC Resource Kit style guidelines ([issue #86](https://github.com/PowerShell/DscResource.Tests/issues/86)).
+  The current rules checks the [Parameter()] attribute format is correct in all parameter blocks.
 
 ### 0.2.0.0
 


### PR DESCRIPTION
This PR adds a new PS Module called DscResource.AnalyzerRules. It contains an initial set of rules for validating resources against the style guidelines and minimum standards for the DSC Resource kit.

These rules are applied like any other PSSA rules, but will currently not cause a test failure if any are violated. Once https://github.com/PowerShell/DscResource.Tests/issues/161 is addressed then we should be able to opt-into triggering failures on these rules.

I've only included only one rule currently (validate the [Parameter()] attribute exists and is formatted correctly) - which can generate 3 different violations. Separating these into different rules results in much slower processing and doesn't really add anything useful IMHO.

I wanted to start really small on this so we'll need to build the rules up over time.

I tried this out on xComputerManagement (which I know has many violations). Here is the AppVeyor run:

https://ci.appveyor.com/project/PlagueHO/xcomputermanagement/build/1.9.59.0#L118

There is an odd message appearing though that only shows up in AppVeyor:
![image](https://user-images.githubusercontent.com/7589164/28304394-81f00926-6beb-11e7-94a7-dc02022e8023.png)

I haven't managed to suppress it or figure out where/why it occurs. It doesn't prevent the code from working and only appears when running in AppVeyor. If anyone has any ideas about the cause feel free to chime in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/162)
<!-- Reviewable:end -->
