### PR TITLE
Add check for dependent modules in Examples and Warns user or installs - Fixes #157

### DIFF
--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -13,6 +13,7 @@ $testHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath 'TestHelper.psm
 Import-Module -Name $testHelperModulePath
 
 $moduleRootFilePath = Split-Path -Path $PSScriptRoot -Parent
+$moduleName = (Get-Item -Path $moduleRootFilePath).Name
 $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
 
 # Identify the repository root path of the resource module
@@ -231,7 +232,6 @@ Describe 'Common Tests - Module Manifest' {
         $minimumPSVersion = [Version]'4.0'
     }
 
-    $moduleName = (Get-Item -Path $moduleRootFilePath).Name
     $moduleManifestPath = Join-Path -Path $moduleRootFilePath -ChildPath "$moduleName.psd1"
 
     <#
@@ -534,6 +534,58 @@ Describe 'Common Tests - Validate Example Files' -Tag 'Examples' {
 
                         try
                         {
+                            # Get the list of additional modules required by the example
+                            $requiredModules = Get-ResourceModulesInConfiguration -ConfigurationPath $exampleToValidate.FullName |
+                                Where-Object -Property Name -ne $moduleName
+
+                            # Check any additional modules required are installed
+                            foreach ($requiredModule in $requiredModules)
+                            {
+                                if (-not (Get-Module @requiredModule -ListAvailable -ErrorAction SilentlyContinue))
+                                {
+                                    # The required module is missing from this machine
+                                    if ($requiredModule.ContainsKey('Version')) {
+                                        $requiredModuleName = ('{0} version {1}' -f $requiredModule.Name, $requiredModule.Version)
+                                    }
+                                    else
+                                    {
+                                        $requiredModuleName = ('{0}' -f $requiredModule.Name)
+                                    }
+
+                                    if ($env:APPVEYOR -eq $true)
+                                    {
+                                        # Tests are running in AppVeyor so just install the module
+                                        $installModuleParams = @{
+                                            Name  = $requiredModule.Name
+                                        }
+
+                                        if ($requiredModule.ContainsKey('Version'))
+                                        {
+                                            $installModuleParams = @{
+                                                RequiredVersion = $requiredModule.Version
+                                            }
+                                        }
+
+                                        Write-Verbose -Message "Installing module $requiredModuleName required to test example." -Verbose
+                                        try
+                                        {
+                                            Install-Module @requiredModule -Scope CurrentUser
+                                        }
+                                        catch
+                                        {
+                                            throw "An error occurred installing the required module $($requiredModuleName) : $_"
+                                        }
+                                    }
+                                    else
+                                    {
+                                        # Warn the user that the test fill fail
+                                        Write-Warning -Message ("Example requires resource module $requiredModuleName but it is not installed on this computer. " + `
+                                            'This test will fail until the required module is installed. ' + `
+                                            'Please install it from the PowerShell Gallery to enable these tests to pass.')
+                                    } # if
+                                } # if
+                            } # foreach
+
                             . $exampleToValidate.FullName
 
                             $exampleCommand = Get-Command -Name Example -ErrorAction SilentlyContinue

--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ Invoke-AppveyorAfterTestTask `
   the AppVeyor "Tests-view".
 * Changed debug message which outputs the type of the $results variable (in
   AppVeyor.psm1) to use Write-Verbose instead of Write-Info ([issue #99](https://github.com/PowerShell/DscResource.Tests/issues/99)).
+* Added `Get-ResourceModulesInConfiguration` to `TestHelper.psm1` to get support installing
+  DSC Resource modules when testing examples.
+* Enable 'Common Tests - Validate Example Files' to install missing required modules if
+  running in AppVeyor or show warning if run by user.
 
 ### 0.2.0.0
 

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -1052,6 +1052,105 @@ function Get-RelativePathFromModuleRoot
     return ($FilePath -replace [Regex]::Escape($ModuleRootFilePath),'').Trim('\')
 }
 
+<#
+    .SYNOPSIS
+        Gets an array of DSC Resource modules imported in a DSC Configuration
+        file.
+
+    .PARAMETER ConfigurationPath
+        The path to the configuration file to get the list from.
+#>
+function Get-ResourceModulesInConfiguration
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ConfigurationPath
+    )
+
+    # Resource modules
+    $listedModules = @()
+
+    # Get the AST object for the configuration
+    $dscConfigurationAST = [System.Management.Automation.Language.Parser]::ParseFile($ConfigurationPath , [ref]$null, [ref]$Null)
+
+    # Get all the Import-DscResource module commands
+    $findAllImportDscResources = {
+        $args[0] -is [System.Management.Automation.Language.DynamicKeywordStatementAst] `
+            -and $args[0].CommandElements[0].Value -eq 'Import-DscResource'
+    }
+
+    $importDscResourceCmds = $dscConfigurationAST.EndBlock.FindAll( $findAllImportDscResources, $true )
+
+    foreach ($importDscResourceCmd in $importDscResourceCmds)
+    {
+        $parameterName = 'ModuleName'
+        $moduleName = ''
+        $moduleVersion = ''
+
+        foreach ($element in $importDscResourceCmd.CommandElements)
+        {
+            # For each element in the Import-DscResource command determine what it means
+            if ($element -is [System.Management.Automation.Language.CommandParameterAst])
+            {
+                $parameterName = $element.ParameterName
+            }
+            elseif ($element -is [System.Management.Automation.Language.StringConstantExpressionAst] `
+                    -and $element.Value -ne 'Import-DscResource')
+            {
+                switch ($parameterName)
+                {
+                    'ModuleName'
+                    {
+                        $moduleName = $element.Value
+                    } # ModuleName
+
+                    'ModuleVersion'
+                    {
+                        $moduleVersion = $element.Value
+                    } # ModuleVersion
+                } # switch
+            }
+            elseif ($element -is [System.Management.Automation.Language.ArrayLiteralAst])
+            {
+                <#
+                    This is an array of strings (usually something like xNetworking,xWebAdministration)
+                    So we need to add each module to the list
+                #>
+                foreach ($item in $element.Elements)
+                {
+                    $listedModules += @{
+                        Name = $item.Value
+                    }
+                } # foreach
+            } # if
+        } # foreach
+
+        # Did a module get identified when stepping through the elements?
+        if (-not [String]::IsNullOrEmpty($moduleName))
+        {
+            if ([String]::IsNullOrEmpty($moduleVersion))
+            {
+                $listedModules += @{
+                    Name = $moduleName
+                }
+            }
+            else
+            {
+                $listedModules += @{
+                    Name    = $moduleName
+                    Version = $moduleVersion
+                }
+            }
+        } # if
+    } # foreach
+
+    return $listedModules
+}
+
 Export-ModuleMember -Function @(
     'New-Nuspec', `
     'Install-ModuleFromPowerShellGallery', `
@@ -1074,5 +1173,6 @@ Export-ModuleMember -Function @(
     'Get-UserProfilePSModulePathItem',
     'Get-PSHomePSModulePathItem',
     'Test-FileHasByteOrderMark',
-    'Get-RelativePathFromModuleRoot'
+    'Get-RelativePathFromModuleRoot',
+    'Get-ResourceModulesInConfiguration'
 )


### PR DESCRIPTION
This PR adds support to identify any dependent modules in Example files (that aren't the module being tested) and will either warn the user they're required (tests will still fail) or if running in AppVeyor will install the module from the PS Gallery.

I added a new function `Get-ResourceModulesInConfiguration` that does the work of extracting any resource modules required in a DSC Configuration. It uses the PowerShell AST for this, but I do have an alternate method using RegEx around that I could use if the AST method isn't to taste.

This is a recreation of PR #158 because I some how messed up the rebase. Sorry about that.

@johlju - are you able to check this off again for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/163)
<!-- Reviewable:end -->
