### PR TITLE
Added new common test checking script files for BOM - Fixes #160

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,5 +1,6 @@
 [
     "Common Tests - Validate Module Files",
     "Common Tests - Validate Markdown Files",
-    "Common Tests - Validate Example Files"
+    "Common Tests - Validate Example Files",
+    "Common Tests - Validate Script Files"
 ]

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -176,6 +176,7 @@ Describe 'Common Tests - Validate Script Files' -Tag 'Script' {
     }
 
     $scriptFiles = Get-TextFilesList -Root $moduleRootFilePath | Where-Object -FilterScript $scriptFilesFilterScript
+
     foreach ($scriptFile in $scriptFiles)
     {
         $filePathOutputName = Get-RelativePathFromModuleRoot `
@@ -229,6 +230,7 @@ Describe 'Common Tests - Validate Module Files' -Tag 'Module' {
     $optIn = Get-PesterDescribeOptInStatus -OptIns $optIns
 
     $moduleFiles = Get-Psm1FileList -FilePath $moduleRootFilePath
+
     foreach ($moduleFile in $moduleFiles)
     {
         $filePathOutputName = Get-RelativePathFromModuleRoot `

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -45,7 +45,8 @@ $testOptInFilePath = Join-Path -Path $repoRootPath -ChildPath '.MetaTestOptIn.js
 # [
 #     "Common Tests - Validate Module Files",
 #     "Common Tests - Validate Markdown Files",
-#     "Common Tests - Validate Example Files"
+#     "Common Tests - Validate Example Files",
+#     "Common Tests - Validate Script Files"
 # ]
 
 $optIns = @()
@@ -162,6 +163,34 @@ Describe 'Common Tests - File Formatting' {
                 }
 
                 $markdownFileHasBom | Should Be $false
+            }
+        }
+    }
+}
+
+Describe 'Common Tests - Validate Script Files' -Tag 'Script' {
+    $optIn = Get-PesterDescribeOptInStatus -OptIns $optIns
+
+    $scriptFilesFilterScript = {
+        '.ps1' -eq $_.Extension
+    }
+
+    $scriptFiles = Get-TextFilesList -Root $moduleRootFilePath | Where-Object -FilterScript $scriptFilesFilterScript
+    foreach ($scriptFile in $scriptFiles)
+    {
+        $filePathOutputName = Get-RelativePathFromModuleRoot `
+                                -FilePath $scriptFile.FullName `
+                                -ModuleRootFilePath $moduleRootFilePath
+
+        Context $filePathOutputName {
+            It ('Script file ''{0}'' should not have Byte Order Mark (BOM)' -f $filePathOutputName) -Skip:(!$optIn) {
+                $scriptFileHasBom = Test-FileHasByteOrderMark -FilePath $scriptFile.FullName
+
+                if ($scriptFileHasBom) {
+                    Write-Warning -Message "$filePathOutputName contain Byte Order Mark (BOM). Use fixer function 'ConvertTo-ASCII'."
+                }
+
+                $scriptFileHasBom | Should Be $false
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ Invoke-AppveyorAfterTestTask `
   DSC Resource modules when testing examples.
 * Enable 'Common Tests - Validate Example Files' to install missing required modules if
   running in AppVeyor or show warning if run by user.
+* Added new common test so that script files (.ps1) are checked for Byte Order
+  Mark (BOM) (issue #160). This test is opt-in using .MetaTestOptIn.json.
 
 ### 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,8 @@ Invoke-AppveyorAfterTestTask `
 * Enable 'Common Tests - Validate Example Files' to install missing required modules if
   running in AppVeyor or show warning if run by user.
 * Added new common test so that script files (.ps1) are checked for Byte Order
-  Mark (BOM) (issue #160). This test is opt-in using .MetaTestOptIn.json.
+  Mark (BOM) ([issue #160](https://github.com/PowerShell/DscResource.Tests/issues/160)).
+  This test is opt-in using .MetaTestOptIn.json.
 
 ### 0.2.0.0
 


### PR DESCRIPTION
Added new common test so that script files (.ps1) are checked for Byte Order Mark (BOM) (issue #160). This test is opt-in using .MetaTestOptIn.json.

This is tested OK here: 
https://ci.appveyor.com/project/johlju/xsqlserver/build/6.0.786.0#L60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/164)
<!-- Reviewable:end -->
