### PR TITLE
Changed debug message which outputs the type of the $results variable - Fixes #99

### DIFF
--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -306,8 +306,9 @@ function Invoke-AppveyorTestScriptTask
         }
     }
 
+    Write-Verbose -Message "Test result Type: $($results.GetType().FullName)"
+
     Write-Info -Message 'Done running tests.'
-    Write-Info -Message "Test result Type: $($results.GetType().Fullname)"
 
     if ($results.FailedCount -gt 0)
     {

--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ Invoke-AppveyorAfterTestTask `
   (issue #143).
 * Updated It-blocks for File Parsing tests so that they are more descriptive for
   the AppVeyor "Tests-view".
+* Changed debug message which outputs the type of the $results variable (in
+  AppVeyor.psm1) to use Write-Verbose instead of Write-Info ([issue #99](https://github.com/PowerShell/DscResource.Tests/issues/99)).
 
 ### 0.2.0.0
 


### PR DESCRIPTION
- Changes to AppVeyor.psm1
  - Changed debug message which outputs the type of the $results variable (in AppVeyor.psm1) to use Write-Verbose instead of Write-Info (issue #99).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/165)
<!-- Reviewable:end -->
