### PR TITLE
Fixed Byte Order Mark (BOM) in files - Fixes #169

### DIFF
--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psd1
@@ -1,4 +1,4 @@
-﻿@{
+@{
 
 # Script module or binary module file associated with this manifest.
 RootModule = 'DscResource.AnalyzerRules.psm1'

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 4.0
+#Requires -Version 4.0
 
 # Import Localized Data
 Import-LocalizedData -BindingVariable localizedData
@@ -52,7 +52,7 @@ function Measure-ParameterBlockParameterAttribute
             foreach ($functionAst in $functionsAst)
             {
                 [System.Management.Automation.Language.Ast[]] $parametersAst = $functionAst.FindAll( $findAllParametersFilter, $true ).Parameters
-                
+
                 foreach ($parameterAst in $parametersAst)
                 {
                     if ($parameterAst.Attributes.Typename.FullName -notcontains 'parameter')

--- a/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
@@ -1,4 +1,4 @@
-﻿ConvertFrom-StringData @'
+ConvertFrom-StringData @'
 # English strings
 ParameterBlockParameterAttributeMissing    = A [Parameter()] attribute must be the first attribute of each parameter and be on its own line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-parameter-block
 ParameterBlockParameterAttributeLowerCase  = The [Parameter()] attribute must start with an upper case 'P'. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-parameter-block

--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Invoke-AppveyorAfterTestTask `
 * Added minimum viable product for applying custom PSSA rules to check adherence to
   DSC Resource Kit style guidelines ([issue #86](https://github.com/PowerShell/DscResource.Tests/issues/86)).
   The current rules checks the [Parameter()] attribute format is correct in all parameter blocks.
+  * Fixed Byte Order Mark (BOM) in files; DscResource.AnalyzerRules.psd1,
+  DscResource.AnalyzerRules.psm1 and en-US/DscResource.AnalyzerRules.psd1
+  ([issue #169](https://github.com/PowerShell/DscResource.Tests/issues/169)).
 
 ### 0.2.0.0
 


### PR DESCRIPTION
- Changes to DscResource.Tests
  - Fixed Byte Order Mark (BOM) in files; DscResource.AnalyzerRules.psd1,
    DscResource.AnalyzerRules.psm1 and en-US/DscResource.AnalyzerRules.psd1 (issue #169).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/171)
<!-- Reviewable:end -->
