### PR TITLE
Added CodeCoverage for Class based resources - Fixes #173

### DIFF
--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -253,13 +253,13 @@ function Invoke-AppveyorTestScriptTask
 
                 # Define the folders to check, if found add the path for codecoverage
                 $possibleModulePaths = @(
-                    "DSCResources",
-                    "DSCClassResources"
+                    'DSCResources',
+                    'DSCClassResources'
                 )
 
                 foreach ($possibleModulePath in $possibleModulePaths)
                 {
-                    if(Test-Path -Path $MainModulePath\$possibleModulePath)
+                    if (Test-Path -Path $MainModulePath\$possibleModulePath)
                     {
                         $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$possibleModulePath\*.psm1"
                         $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$possibleModulePath\**\*.psm1"

--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -261,8 +261,8 @@ function Invoke-AppveyorTestScriptTask
                 {
                     if(Test-Path -Path $MainModulePath\$possibleModulePath)
                     {
-                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$posibleModulePath\*.psm1"
-                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$posibleModulePath\**\*.psm1"
+                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$possibleModulePath\*.psm1"
+                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$possibleModulePath\**\*.psm1"
                     }
                 }
                 Write-Warning -Message "here are the pathsafter checks: $codeCoveragePaths"

--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -247,23 +247,27 @@ function Invoke-AppveyorTestScriptTask
                 Write-Warning -Message 'Code coverage statistics are being calculated. This will slow the start of the tests while the code matrix is built. Please be patient.'
 
                 # Only add code path for DSCResources if they exist.
-                if (Test-Path -Path "$MainModulePath\DSCResources" )
+                $codeCoveragePaths = @(
+                    "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
+                )
+                
+                # Define the folders to check if they exist, if found add the path to be used for codecoverage
+                $possibleModulePaths = @(
+                    "DSCResources",
+                    "DSCClassResources"
+                )
+
+                foreach ($possibleModulePath in $possibleModulePaths)
                 {
-                    $pesterParameters += @{
-                        CodeCoverage = @(
-                            "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
-                            "$env:APPVEYOR_BUILD_FOLDER\DSCResources\*.psm1"
-                            "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"
-                        )
+                    if(Test-Path -Path $MainModulePath\$possibleModulePath)
+                    {
+                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$posibleModulePath\*.psm1"
+                        $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$posibleModulePath\**\*.psm1"
                     }
                 }
-                else
-                {
-                    $pesterParameters += @{
-                        CodeCoverage = @(
-                            "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
-                        )
-                    }
+                
+                $pesterParameters += @{
+                    CodeCoverage = $codeCoveragePaths
                 }
             }
 

--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -250,8 +250,8 @@ function Invoke-AppveyorTestScriptTask
                 $codeCoveragePaths = @(
                     "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
                 )
-                Write-Warning -Message "here are the paths: $codeCoveragePaths"
-                # Define the folders to check if they exist, if found add the path to be used for codecoverage
+
+                # Define the folders to check, if found add the path for codecoverage
                 $possibleModulePaths = @(
                     "DSCResources",
                     "DSCClassResources"
@@ -265,7 +265,7 @@ function Invoke-AppveyorTestScriptTask
                         $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$possibleModulePath\**\*.psm1"
                     }
                 }
-                Write-Warning -Message "here are the pathsafter checks: $codeCoveragePaths"
+
                 $pesterParameters += @{
                     CodeCoverage = $codeCoveragePaths
                 }
@@ -391,8 +391,7 @@ function Invoke-AppveyorTestScriptTask
                 $pesterParameters += @{
                     Path = $testObjectOrder.TestPath
                 }
-                Write-Warning "pester params for codecov: $($pesterParamaters.CodeCoverage)"
-               
+                               
                 $results = Invoke-Pester @pesterParameters
             }
             else

--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -250,7 +250,7 @@ function Invoke-AppveyorTestScriptTask
                 $codeCoveragePaths = @(
                     "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
                 )
-                
+
                 # Define the folders to check if they exist, if found add the path to be used for codecoverage
                 $possibleModulePaths = @(
                     "DSCResources",
@@ -391,7 +391,8 @@ function Invoke-AppveyorTestScriptTask
                 $pesterParameters += @{
                     Path = $testObjectOrder.TestPath
                 }
-
+                Write-Warning "pester params for codecov: $($pesterParamaters.CodeCoverage)"
+               
                 $results = Invoke-Pester @pesterParameters
             }
             else

--- a/AppVeyor.psm1
+++ b/AppVeyor.psm1
@@ -250,7 +250,7 @@ function Invoke-AppveyorTestScriptTask
                 $codeCoveragePaths = @(
                     "$env:APPVEYOR_BUILD_FOLDER\*.psm1"
                 )
-
+                Write-Warning -Message "here are the paths: $codeCoveragePaths"
                 # Define the folders to check if they exist, if found add the path to be used for codecoverage
                 $possibleModulePaths = @(
                     "DSCResources",
@@ -265,7 +265,7 @@ function Invoke-AppveyorTestScriptTask
                         $codeCoveragePaths += "$env:APPVEYOR_BUILD_FOLDER\$posibleModulePath\**\*.psm1"
                     }
                 }
-                
+                Write-Warning -Message "here are the pathsafter checks: $codeCoveragePaths"
                 $pesterParameters += @{
                     CodeCoverage = $codeCoveragePaths
                 }

--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Configuration MSFT_SqlAlwaysOnService_EnableAlwaysOn_Config
 * Updated documentation in README.md and comment-based help in TestHelp.psm1 to
   use the new name of the renamed SqlServerDsc resource module.
 * Fixed minor typo in manifest for the CodeCoverage module.
+* Added Invoke-AppveyorTestScriptTask cmdlet functionality for CodeCoverage for Class based resources ([issue #173](https://github.com/PowerShell/DscResource.Tests/issues/173))
 
 ### 0.2.0.0
 

--- a/Tests/Unit/AppVeyor.Tests.ps1
+++ b/Tests/Unit/AppVeyor.Tests.ps1
@@ -1,0 +1,74 @@
+$script:ModuleName = 'AppVeyor'
+$script:moduleRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+$env:APPVEYOR_BUILD_FOLDER = 'c:\project\'
+Describe "$($script:ModuleName) Unit Tests" {
+    BeforeAll {
+        Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "$($script:ModuleName).psm1") -Force
+        Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "TestHelper.psm1") -Force
+    } # End BeforeAll
+
+    InModuleScope $script:ModuleName {
+        # Added functions that are specific to AppVeyor environment so mocks would not fail
+        Function Add-AppveyorTest { }
+        Function Resolve-CoverageInfo { }
+        Function Invoke-UploadCoveCoveIoReport { }
+        Describe 'Invoke-AppveyorTestScriptTask' { 
+            context 'CodeCoverage' {
+                $pesterReturnedValues = @{
+                    PassedCount = 1
+                    FailedCount = 0
+                }
+                BeforeAll {
+                    Mock -CommandName Add-AppveyorTest -MockWith { }
+                    Mock -CommandName Push-TestArtifact -MockWith { }
+                    Mock -CommandName Invoke-UploadCoveCoveIoReport -MockWith { }
+                    Mock -CommandName Test-Path -MockWith { return $False }
+                    Mock -CommandName Get-ChildItem -MockWith { return "file.Tests.ps1" }
+                    Mock -CommandName Get-ChildItem -MockWith { return $null } -ParameterFilter {$Include -eq '*.config.ps1'}
+                    Mock -CommandName Resolve-CoverageInfo -MockWith { }
+                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues}
+                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues} -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues} -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                    # Making sure there is no output when performing tests 
+                    Mock -CommandName Write-Verbose -MockWith { }
+                    Mock -CommandName Write-Warning -MockWith { }
+                    Mock -CommandName Write-Info -MockWith { }
+                } # End BeforeAll
+                AfterEach {
+                    Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                    Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                    Assert-MockCalled -CommandName Test-Path -Times 2 -Exactly -Scope It
+                    Assert-MockCalled -CommandName Get-ChildItem -Times 1 -Exactly -Scope It -ParameterFilter {$Include -eq '*.config.ps1'}
+                    Assert-MockCalled -CommandName Get-ChildItem -Times 2 -Exactly -Scope It
+                } # End AfterEach
+                It 'Should only include DSCClassResources for CodeCoverage' {
+                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                    Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                    
+                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                } # End It DSCClassResources only
+                It 'Should only include DSCResources for CodeCoverage' {
+                    Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                    
+                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                } # End It DSCResources only
+                It 'Should use DSCResources and DSCClassResources for CodeCoverage' {
+                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                    
+                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                } # End It Both DSCResources and DSCClassResources
+            } # End context CodeCoverage
+        } # End Describe Invoke-AppveyorTestScriptTask Tests
+    } # End inModuleScope
+} # End Describe Module Unit Tests

--- a/Tests/Unit/AppVeyor.Tests.ps1
+++ b/Tests/Unit/AppVeyor.Tests.ps1
@@ -1,6 +1,9 @@
 $script:ModuleName = 'AppVeyor'
 $script:moduleRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
-$env:APPVEYOR_BUILD_FOLDER = 'c:\project\'
+if($null -eq $env:APPVEYOR_BUILD_FOLDER)
+{
+    $env:APPVEYOR_BUILD_FOLDER = 'C:\projects\dscresource-tests'
+}
 Describe "$($script:ModuleName) Unit Tests" {
     BeforeAll {
         Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "$($script:ModuleName).psm1") -Force

--- a/Tests/Unit/AppVeyor.Tests.ps1
+++ b/Tests/Unit/AppVeyor.Tests.ps1
@@ -6,7 +6,7 @@ if ($null -eq $env:APPVEYOR_BUILD_FOLDER)
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "$($script:ModuleName).psm1") -Force
-Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "TestHelper.psm1") -Force
+Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath 'TestHelper.psm1') -Force
 
 InModuleScope $script:ModuleName {
     # Added functions that are specific to AppVeyor environment so mocks would not fail
@@ -15,7 +15,7 @@ InModuleScope $script:ModuleName {
     Function Invoke-UploadCoveCoveIoReport { }
 
     Describe 'AppVoyer\Invoke-AppveyorTestScriptTask' { 
-        Context 'When CodeCoverage requires additional direcotries' {
+        Context 'When CodeCoverage requires additional directories' {
             $pesterReturnedValues = @{
                 PassedCount = 1
                 FailedCount = 0
@@ -24,52 +24,52 @@ InModuleScope $script:ModuleName {
                 Mock -CommandName Add-AppveyorTest
                 Mock -CommandName Push-TestArtifact
                 Mock -CommandName Invoke-UploadCoveCoveIoReport
-                Mock -CommandName Test-Path -MockWith { return $False }
-                Mock -CommandName Get-ChildItem -MockWith { return "file.Tests.ps1" }
-                Mock -CommandName Get-ChildItem -MockWith { return $null } -ParameterFilter {$Include -eq '*.config.ps1'}
+                Mock -CommandName Test-Path -MockWith { return $false }
+                Mock -CommandName Get-ChildItem -MockWith { return 'file.Tests.ps1' }
+                Mock -CommandName Get-ChildItem -MockWith { return $null } -ParameterFilter { $Include -eq '*.config.ps1' }
                 Mock -CommandName Resolve-CoverageInfo
                 Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues }
-                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1" }
+                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1" }
                 # Making sure there is no output when performing tests 
                 Mock -CommandName Write-Verbose
                 Mock -CommandName Write-Warning
                 Mock -CommandName Write-Info
             } # End BeforeAll
             AfterEach {
-                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter { $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources" }
+                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter { $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources" }
                 Assert-MockCalled -CommandName Test-Path -Times 2 -Exactly -Scope It
-                Assert-MockCalled -CommandName Get-ChildItem -Times 1 -Exactly -Scope It -ParameterFilter {$Include -eq '*.config.ps1'}
+                Assert-MockCalled -CommandName Get-ChildItem -Times 1 -Exactly -Scope It -ParameterFilter { $Include -eq '*.config.ps1' }
                 Assert-MockCalled -CommandName Get-ChildItem -Times 2 -Exactly -Scope It
             } # End AfterEach
             It 'Should only include DSCClassResources for CodeCoverage' {
-                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter { $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources" }
+                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter { $Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources" }
                 
                 { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1" }
+                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1" }
             } # End It DSCClassResources only
             It 'Should only include DSCResources for CodeCoverage' {
-                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter { $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources" }
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter { $Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources" }
                 
                 { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1" }
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1" }
             } # End It DSCResources only
             It 'Should include DSCResources and DSCClassResources for CodeCoverage' {
-                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter { $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources" }
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter { $Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources" }
                 
                 { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
 
-                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1" }
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter { $CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1" }
             } # End It Both DSCResources and DSCClassResources
-        } # End Context When CodeCoverage requires additional direcotries
+        } # End Context When CodeCoverage requires additional directories
     } # End Describe AppVoyer\Invoke-AppveyorTestScriptTask
 } # End InModuleScope

--- a/Tests/Unit/AppVeyor.Tests.ps1
+++ b/Tests/Unit/AppVeyor.Tests.ps1
@@ -1,77 +1,75 @@
 $script:ModuleName = 'AppVeyor'
 $script:moduleRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
-if($null -eq $env:APPVEYOR_BUILD_FOLDER)
+if ($null -eq $env:APPVEYOR_BUILD_FOLDER)
 {
     $env:APPVEYOR_BUILD_FOLDER = 'C:\projects\dscresource-tests'
 }
-Describe "$($script:ModuleName) Unit Tests" {
-    BeforeAll {
-        Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "$($script:ModuleName).psm1") -Force
-        Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "TestHelper.psm1") -Force
-    } # End BeforeAll
 
-    InModuleScope $script:ModuleName {
-        # Added functions that are specific to AppVeyor environment so mocks would not fail
-        Function Add-AppveyorTest { }
-        Function Resolve-CoverageInfo { }
-        Function Invoke-UploadCoveCoveIoReport { }
-        Describe 'Invoke-AppveyorTestScriptTask' { 
-            context 'CodeCoverage' {
-                $pesterReturnedValues = @{
-                    PassedCount = 1
-                    FailedCount = 0
-                }
-                BeforeAll {
-                    Mock -CommandName Add-AppveyorTest -MockWith { }
-                    Mock -CommandName Push-TestArtifact -MockWith { }
-                    Mock -CommandName Invoke-UploadCoveCoveIoReport -MockWith { }
-                    Mock -CommandName Test-Path -MockWith { return $False }
-                    Mock -CommandName Get-ChildItem -MockWith { return "file.Tests.ps1" }
-                    Mock -CommandName Get-ChildItem -MockWith { return $null } -ParameterFilter {$Include -eq '*.config.ps1'}
-                    Mock -CommandName Resolve-CoverageInfo -MockWith { }
-                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues}
-                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues} -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                    Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues} -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
-                    # Making sure there is no output when performing tests 
-                    Mock -CommandName Write-Verbose -MockWith { }
-                    Mock -CommandName Write-Warning -MockWith { }
-                    Mock -CommandName Write-Info -MockWith { }
-                } # End BeforeAll
-                AfterEach {
-                    Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                    Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
-                    Assert-MockCalled -CommandName Test-Path -Times 2 -Exactly -Scope It
-                    Assert-MockCalled -CommandName Get-ChildItem -Times 1 -Exactly -Scope It -ParameterFilter {$Include -eq '*.config.ps1'}
-                    Assert-MockCalled -CommandName Get-ChildItem -Times 2 -Exactly -Scope It
-                } # End AfterEach
-                It 'Should only include DSCClassResources for CodeCoverage' {
-                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                    Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
-                    
-                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "$($script:ModuleName).psm1") -Force
+Import-Module -Name (Join-Path -Path $script:moduleRootPath -ChildPath "TestHelper.psm1") -Force
 
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
-                } # End It DSCClassResources only
-                It 'Should only include DSCResources for CodeCoverage' {
-                    Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
-                    
-                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+InModuleScope $script:ModuleName {
+    # Added functions that are specific to AppVeyor environment so mocks would not fail
+    Function Add-AppveyorTest { }
+    Function Resolve-CoverageInfo { }
+    Function Invoke-UploadCoveCoveIoReport { }
 
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
-                } # End It DSCResources only
-                It 'Should use DSCResources and DSCClassResources for CodeCoverage' {
-                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
-                    Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
-                    
-                    { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+    Describe 'AppVoyer\Invoke-AppveyorTestScriptTask' { 
+        Context 'When CodeCoverage requires additional direcotries' {
+            $pesterReturnedValues = @{
+                PassedCount = 1
+                FailedCount = 0
+            }
+            BeforeAll {
+                Mock -CommandName Add-AppveyorTest
+                Mock -CommandName Push-TestArtifact
+                Mock -CommandName Invoke-UploadCoveCoveIoReport
+                Mock -CommandName Test-Path -MockWith { return $False }
+                Mock -CommandName Get-ChildItem -MockWith { return "file.Tests.ps1" }
+                Mock -CommandName Get-ChildItem -MockWith { return $null } -ParameterFilter {$Include -eq '*.config.ps1'}
+                Mock -CommandName Resolve-CoverageInfo
+                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues }
+                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                Mock -CommandName Invoke-Pester -MockWith { return $pesterReturnedValues } -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+                # Making sure there is no output when performing tests 
+                Mock -CommandName Write-Verbose
+                Mock -CommandName Write-Warning
+                Mock -CommandName Write-Info
+            } # End BeforeAll
+            AfterEach {
+                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                Assert-MockCalled -CommandName Test-Path -Times 2 -Exactly -Scope It
+                Assert-MockCalled -CommandName Get-ChildItem -Times 1 -Exactly -Scope It -ParameterFilter {$Include -eq '*.config.ps1'}
+                Assert-MockCalled -CommandName Get-ChildItem -Times 2 -Exactly -Scope It
+            } # End AfterEach
+            It 'Should only include DSCClassResources for CodeCoverage' {
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                
+                { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
-                    Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
-                } # End It Both DSCResources and DSCClassResources
-            } # End context CodeCoverage
-        } # End Describe Invoke-AppveyorTestScriptTask Tests
-    } # End inModuleScope
-} # End Describe Module Unit Tests
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+            } # End It DSCClassResources only
+            It 'Should only include DSCResources for CodeCoverage' {
+                Mock -CommandName Test-Path -MockWith { return $false } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                
+                { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+
+                Assert-MockCalled -CommandName Invoke-Pester -Times 0 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+            } # End It DSCResources only
+            It 'Should include DSCResources and DSCClassResources for CodeCoverage' {
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources"}
+                Mock -CommandName Test-Path -MockWith { return $true } -ParameterFilter {$Path -and $Path -eq "$env:APPVEYOR_BUILD_FOLDER\DSCResources"}
+                
+                { Invoke-AppveyorTestScriptTask -CodeCoverage } | Should Not Throw
+
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCClassResources\**\*.psm1"}
+                Assert-MockCalled -CommandName Invoke-Pester -Times 1 -Exactly -Scope It -ParameterFilter {$CodeCoverage -contains "$env:APPVEYOR_BUILD_FOLDER\DSCResources\**\*.psm1"}
+            } # End It Both DSCResources and DSCClassResources
+        } # End Context When CodeCoverage requires additional direcotries
+    } # End Describe AppVoyer\Invoke-AppveyorTestScriptTask
+} # End InModuleScope


### PR DESCRIPTION
* Added ```Invoke-AppveyorTestScriptTask``` cmdlet functionality for CodeCoverage for Class based resources ([issue #173](https://github.com/PowerShell/DscResource.Tests/issues/173))
* Added tests for module ```AppVoyer.psm1``` and tested ```Invoke-AppveyorTestScriptTask``` to verify it adds all the folders needed for CodeCoverage when running ```Invoke-Pester```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/212)
<!-- Reviewable:end -->
