### PR TITLE
Container testing - Handling of tag for images are now correct

### DIFF
--- a/DscResource.Container/DscResource.Container.psm1
+++ b/DscResource.Container/DscResource.Container.psm1
@@ -159,10 +159,10 @@ function New-Container
     }
 
     # Make sure we have the correct container images available.
-    [System.String[]] $dockerImages = docker images --format "{{.Repository}}"
+    [System.String[]] $dockerImages = docker images --format "{{.Repository}}:{{.Tag}}"
     if (-not $dockerImages.Contains($ImageName))
     {
-        Write-Info ($script:localizedData.DockerIsNotAvailable -f $ImageName)
+        Write-Info ($script:localizedData.DownloadingImage -f $ImageName)
         <#
             Pulling the latest image. Using Out-Null so it does
             not output download information.

--- a/README.md
+++ b/README.md
@@ -580,6 +580,9 @@ These are the artifacts that differ when running tests using a container.
   so that it is possible to change the color of the text that is written.
 * Added module DscResource.Container which contain logic to handle the container
   testing when unit tests are run in a Docker Windows container.
+* Fix container bugs
+  * Handling of tag for images are now correct.
+  * Correct message is displayed when downloading an image.
 
 ### 0.2.0.0
 


### PR DESCRIPTION
- Fix container bugs
  - Handling of tag for images are now correct.
  - Correct message is displayed when downloading an image.

A bug snuck in during the review that I didn't see until I was updated SqlServerDsc with this. We added 'latest' tag to the image name, didn't realize that it broke evaluation for existing container images, so it ended up pulling the latest image from Docker Hub, which takes "forever".
This PR solves the evaluation so it can handle the tag 'latest'. This fix is needed for the next iteration of container testing as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/214)
<!-- Reviewable:end -->
