### PR TITLE
Adding rule name for custom rules

### DIFF
--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -6,6 +6,7 @@ Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'DscResource.Analy
 # Import Localized Data
 Import-LocalizedData -BindingVariable localizedData
 
+$script:moduleName = $MyInvocation.MyCommand.Name -replace '.psm1'
 $script:diagnosticRecordType = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]
 $script:diagnosticRecord = @{
     Message  = ''
@@ -62,17 +63,23 @@ function Measure-ParameterBlockParameterAttribute
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeMissing
 
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
             elseif ($ParameterAst.Attributes[0].TypeName.FullName -ne 'parameter')
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeWrongPlace
 
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
+
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
             elseif ($ParameterAst.Attributes[0].TypeName.FullName -cne 'Parameter')
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeLowerCase
+
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
 
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
@@ -127,7 +134,7 @@ function Measure-ParameterBlockMandatoryNamedArgument
         if (!$inAClass)
         {
             if ($NamedAttributeArgumentAst.ArgumentName -eq 'Mandatory')
-            {
+            {    
                 $script:diagnosticRecord['Extent'] = $NamedAttributeArgumentAst.Extent
 
                 if ($NamedAttributeArgumentAst)
@@ -139,6 +146,8 @@ function Measure-ParameterBlockMandatoryNamedArgument
                         if ($value -eq $false)
                         {
                             $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+
+                            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
 
                             $script:diagnosticRecord -as $script:diagnosticRecordType
                         }
@@ -159,6 +168,8 @@ function Measure-ParameterBlockMandatoryNamedArgument
                     if ($invalidFormat)
                     {
                         $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+
+                        $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
 
                         $script:diagnosticRecord -as $script:diagnosticRecordType
                     }
@@ -215,18 +226,21 @@ function Measure-FunctionBlockBraces
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -279,18 +293,21 @@ function Measure-IfStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -343,18 +360,21 @@ function Measure-ForEachStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -407,18 +427,21 @@ function Measure-DoUntilStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -471,18 +494,21 @@ function Measure-DoWhileStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -535,18 +561,21 @@ function Measure-WhileStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -599,18 +628,21 @@ function Measure-ForStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -668,17 +700,20 @@ function Measure-SwitchStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
         elseif (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -731,18 +766,21 @@ function Measure-TryStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -795,18 +833,21 @@ function Measure-CatchClause
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceNotOnSameLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         }
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
+            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -860,18 +901,21 @@ function Measure-TypeDefinition
             if (Test-StatementOpeningBraceOnSameLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceNotOnSameLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
         } # if
@@ -880,18 +924,21 @@ function Measure-TypeDefinition
             if (Test-StatementOpeningBraceOnSameLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceNotOnSameLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
         } # if

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -6,12 +6,11 @@ Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'DscResource.Analy
 # Import Localized Data
 Import-LocalizedData -BindingVariable localizedData
 
-$script:moduleName = $MyInvocation.MyCommand.Name -replace '.psm1'
 $script:diagnosticRecordType = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]
 $script:diagnosticRecord = @{
     Message  = ''
     Extent   = $null
-    RuleName = $PSCmdlet.MyInvocation.InvocationName
+    RuleName = $null
     Severity = 'Warning'
 }
 
@@ -51,6 +50,7 @@ function Measure-ParameterBlockParameterAttribute
     try
     {
         $script:diagnosticRecord['Extent'] = $ParameterAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
         [System.Boolean] $inAClass = Test-IsInClass -Ast $ParameterAst
         
         <# 
@@ -63,23 +63,17 @@ function Measure-ParameterBlockParameterAttribute
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeMissing
 
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
-
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
             elseif ($ParameterAst.Attributes[0].TypeName.FullName -ne 'parameter')
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeWrongPlace
 
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
-
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
             elseif ($ParameterAst.Attributes[0].TypeName.FullName -cne 'Parameter')
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterAttributeLowerCase
-
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
 
                 $script:diagnosticRecord -as $script:diagnosticRecordType
             }
@@ -125,6 +119,7 @@ function Measure-ParameterBlockMandatoryNamedArgument
 
     try
     {
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
         [System.Boolean] $inAClass = Test-IsInClass -Ast $NamedAttributeArgumentAst
 
         <# 
@@ -134,7 +129,7 @@ function Measure-ParameterBlockMandatoryNamedArgument
         if (!$inAClass)
         {
             if ($NamedAttributeArgumentAst.ArgumentName -eq 'Mandatory')
-            {    
+            {
                 $script:diagnosticRecord['Extent'] = $NamedAttributeArgumentAst.Extent
 
                 if ($NamedAttributeArgumentAst)
@@ -146,8 +141,6 @@ function Measure-ParameterBlockMandatoryNamedArgument
                         if ($value -eq $false)
                         {
                             $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-
-                            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
 
                             $script:diagnosticRecord -as $script:diagnosticRecordType
                         }
@@ -168,8 +161,6 @@ function Measure-ParameterBlockMandatoryNamedArgument
                     if ($invalidFormat)
                     {
                         $script:diagnosticRecord['Message'] = $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-
-                        $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
 
                         $script:diagnosticRecord -as $script:diagnosticRecordType
                     }
@@ -218,6 +209,7 @@ function Measure-FunctionBlockBraces
     try
     {
         $script:diagnosticRecord['Extent'] = $FunctionDefinitionAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $FunctionDefinitionAst.Extent
@@ -226,21 +218,18 @@ function Measure-FunctionBlockBraces
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -285,6 +274,7 @@ function Measure-IfStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $IfStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $IfStatementAst.Extent
@@ -293,21 +283,18 @@ function Measure-IfStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -352,6 +339,7 @@ function Measure-ForEachStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $ForEachStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $ForEachStatementAst.Extent
@@ -360,21 +348,18 @@ function Measure-ForEachStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -419,6 +404,7 @@ function Measure-DoUntilStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $DoUntilStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $DoUntilStatementAst.Extent
@@ -427,21 +413,18 @@ function Measure-DoUntilStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -486,6 +469,7 @@ function Measure-DoWhileStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $DoWhileStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $DoWhileStatementAst.Extent
@@ -494,21 +478,18 @@ function Measure-DoWhileStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -553,6 +534,7 @@ function Measure-WhileStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $WhileStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $WhileStatementAst.Extent
@@ -561,21 +543,18 @@ function Measure-WhileStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -620,6 +599,7 @@ function Measure-ForStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $ForStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $ForStatementAst.Extent
@@ -628,21 +608,18 @@ function Measure-ForStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -687,6 +664,7 @@ function Measure-SwitchStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $SwitchStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $SwitchStatementAst.Extent
@@ -700,20 +678,17 @@ function Measure-SwitchStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
         elseif (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -758,6 +733,7 @@ function Measure-TryStatement
     try
     {
         $script:diagnosticRecord['Extent'] = $TryStatementAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $TryStatementAst.Extent
@@ -766,21 +742,18 @@ function Measure-TryStatement
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -825,6 +798,7 @@ function Measure-CatchClause
     try
     {
         $script:diagnosticRecord['Extent'] = $CatchClauseAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $CatchClauseAst.Extent
@@ -833,21 +807,18 @@ function Measure-CatchClause
         if (Test-StatementOpeningBraceOnSameLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceNotOnSameLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         }
 
         if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
 
         if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
         {
             $script:diagnosticRecord['Message'] = $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
-            $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             $script:diagnosticRecord -as $diagnosticRecordType
         } # if
     }
@@ -891,6 +862,7 @@ function Measure-TypeDefinition
     try
     {
         $script:diagnosticRecord['Extent'] = $TypeDefinitionAst.Extent
+        $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $testParameters = @{
             StatementBlock = $TypeDefinitionAst.Extent
@@ -901,21 +873,18 @@ function Measure-TypeDefinition
             if (Test-StatementOpeningBraceOnSameLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceNotOnSameLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
         } # if
@@ -924,21 +893,18 @@ function Measure-TypeDefinition
             if (Test-StatementOpeningBraceOnSameLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceNotOnSameLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsNotFollowedByNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
 
             if (Test-StatementOpeningBraceIsFollowedByMoreThanOneNewLine @testParameters)
             {
                 $script:diagnosticRecord['Message'] = $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $script:diagnosticRecord['RuleName'] = "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 $script:diagnosticRecord -as $diagnosticRecordType
             } # if
         } # if

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -430,14 +430,17 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     if ($null -ne $errorPssaRulesOutput)
                     {
                         Write-Warning -Message 'Error-level PSSA rule(s) did not pass.'
-                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
+                        $ruleCollection = $errorPssaRulesOutput | Group-Object -Property RuleName
 
-                        foreach ($errorPssaRuleOutput in $errorPssaRulesOutput)
+                        foreach ($ruleNameGroup in $ruleCollection)
                         {
-                            Write-Warning -Message "PSSA Rule Name: $($errorPssaRuleOutput.RuleName) "
-                            Write-Warning -Message "$($errorPssaRuleOutput.ScriptName) (Line $($errorPssaRuleOutput.Line)): $($errorPssaRuleOutput.Message)"
+                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed:"
+                            foreach ($rule in $ruleNameGroup.Group)
+                            {
+                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+                            }
                         }
-
+                    
                         Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
                     }
 
@@ -450,14 +453,16 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     if ($null -ne $requiredPssaRulesOutput)
                     {
                         Write-Warning -Message 'Required PSSA rule(s) did not pass.'
-                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
+                        $ruleCollection = $requiredPssaRulesOutput | Group-Object -Property RuleName
 
-                        foreach ($requiredPssaRuleOutput in $requiredPssaRulesOutput)
+                        foreach ($ruleNameGroup in $ruleCollection)
                         {
-                            Write-Warning -Message "PSSA Rule Name: $($requiredPssaRuleOutput.RuleName) "
-                            Write-Warning -Message "$($requiredPssaRuleOutput.ScriptName) (Line $($requiredPssaRuleOutput.Line)): $($requiredPssaRuleOutput.Message)"
+                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed:"
+                            foreach ($rule in $ruleNameGroup.Group)
+                            {
+                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+                            }
                         }
-
                         Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
                     }
 
@@ -477,12 +482,15 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     if ($null -ne $flaggedPssaRulesOutput)
                     {
                         Write-Warning -Message 'Flagged PSSA rule(s) did not pass.'
-                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed or approved to be suppressed:'
+                        $ruleCollection = $flaggedPssaRulesOutput | Group-Object -Property RuleName
 
-                        foreach ($flaggedPssaRuleOutput in $flaggedPssaRulesOutput)
+                        foreach ($ruleNameGroup in $ruleCollection)
                         {
-                            Write-Warning -Message "PSSA Rule Name: $($flaggedPssaRuleOutput.RuleName) "
-                            Write-Warning -Message "$($flaggedPssaRuleOutput.ScriptName) (Line $($flaggedPssaRuleOutput.Line)): $($flaggedPssaRuleOutput.Message)"
+                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
+                            foreach ($rule in $ruleNameGroup.Group)
+                            {
+                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+                            }
                         }
 
                         Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
@@ -506,12 +514,15 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     if ($null -ne $newErrorPssaRulesOutput)
                     {
                         Write-Warning -Message 'Recently-added, error-level PSSA rule(s) did not pass.'
-                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed or approved to be suppressed:'
+                        $ruleCollection = $newErrorPssaRulesOutput | Group-Object -Property RuleName
 
-                        foreach ($newErrorPssaRuleOutput in $newErrorPssaRulesOutput)
+                        foreach ($ruleNameGroup in $ruleCollection)
                         {
-                            Write-Warning -Message "PSSA Rule Name: $($newErrorPssaRuleOutput.RuleName) "
-                            Write-Warning -Message "$($newErrorPssaRuleOutput.ScriptName) (Line $($newErrorPssaRuleOutput.Line)): $($newErrorPssaRuleOutput.Message)"
+                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
+                            foreach ($rule in $ruleNameGroup.Group)
+                            {
+                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+                            }
                         }
 
                         Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
@@ -555,12 +566,15 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
                     if ($null -ne $customPssaRulesOutput)
                     {
                         Write-Warning -Message 'Custom DSC Resource Kit PSSA rule(s) did not pass.'
-                        Write-Warning -Message 'The following PSScriptAnalyzer errors need to be fixed:'
+                        $ruleCollection = $customPssaRulesOutput | Group-Object -Property RuleName
 
-                        foreach ($customPssaRuleOutput in $customPssaRulesOutput)
+                        foreach ($ruleNameGroup in $ruleCollection)
                         {
-                            Write-Warning -Message "Custom PSSA Rule Name: $($customPssaRuleOutput.RuleName) "
-                            Write-Warning -Message "$($customPssaRuleOutput.ScriptName) (Line $($customPssaRuleOutput.Line)): $($customPssaRuleOutput.Message)"
+                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
+                            foreach ($rule in $ruleNameGroup.Group)
+                            {
+                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+                            }
                         }
 
                         Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -429,19 +429,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     if ($null -ne $errorPssaRulesOutput)
                     {
-                        Write-Warning -Message 'Error-level PSSA rule(s) did not pass.'
-                        $ruleCollection = $errorPssaRulesOutput | Group-Object -Property RuleName
-
-                        foreach ($ruleNameGroup in $ruleCollection)
-                        {
-                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed:"
-                            foreach ($rule in $ruleNameGroup.Group)
-                            {
-                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
-                            }
-                        }
-                    
-                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                        Write-PsScriptAnalyzerWarning -PssaRuleOutput $errorPssaRulesOutput -RuleType 'Error-Level'
                     }
 
                     $errorPssaRulesOutput | Should -Be $null
@@ -452,18 +440,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     if ($null -ne $requiredPssaRulesOutput)
                     {
-                        Write-Warning -Message 'Required PSSA rule(s) did not pass.'
-                        $ruleCollection = $requiredPssaRulesOutput | Group-Object -Property RuleName
-
-                        foreach ($ruleNameGroup in $ruleCollection)
-                        {
-                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed:"
-                            foreach ($rule in $ruleNameGroup.Group)
-                            {
-                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
-                            }
-                        }
-                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                        Write-PsScriptAnalyzerWarning -PssaRuleOutput $requiredPssaRulesOutput -RuleType 'Required'
                     }
 
                     if ($null -ne $requiredPssaRulesOutput -and (Get-OptInStatus -OptIns $optIns -Name 'Common Tests - Required Script Analyzer Rules'))
@@ -481,19 +458,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     if ($null -ne $flaggedPssaRulesOutput)
                     {
-                        Write-Warning -Message 'Flagged PSSA rule(s) did not pass.'
-                        $ruleCollection = $flaggedPssaRulesOutput | Group-Object -Property RuleName
-
-                        foreach ($ruleNameGroup in $ruleCollection)
-                        {
-                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
-                            foreach ($rule in $ruleNameGroup.Group)
-                            {
-                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
-                            }
-                        }
-
-                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                        Write-PsScriptAnalyzerWarning -PssaRuleOutput $flaggedPssaRulesOutput -RuleType 'Flagged'
                     }
 
                     if ($null -ne $flaggedPssaRulesOutput -and (Get-OptInStatus -OptIns $optIns -Name 'Common Tests - Flagged Script Analyzer Rules'))
@@ -513,19 +478,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     if ($null -ne $newErrorPssaRulesOutput)
                     {
-                        Write-Warning -Message 'Recently-added, error-level PSSA rule(s) did not pass.'
-                        $ruleCollection = $newErrorPssaRulesOutput | Group-Object -Property RuleName
-
-                        foreach ($ruleNameGroup in $ruleCollection)
-                        {
-                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
-                            foreach ($rule in $ruleNameGroup.Group)
-                            {
-                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
-                            }
-                        }
-
-                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                        Write-PsScriptAnalyzerWarning -PssaRuleOutput $newErrorPssaRulesOutput -RuleType 'Recently-added'
                     }
 
                     if ($null -ne $newErrorPssaRulesOutput -and (Get-OptInStatus -OptIns $optIns -Name 'Common Tests - New Error-Level Script Analyzer Rules'))
@@ -565,19 +518,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                     if ($null -ne $customPssaRulesOutput)
                     {
-                        Write-Warning -Message 'Custom DSC Resource Kit PSSA rule(s) did not pass.'
-                        $ruleCollection = $customPssaRulesOutput | Group-Object -Property RuleName
-
-                        foreach ($ruleNameGroup in $ruleCollection)
-                        {
-                            Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed or approved to be suppressed:"
-                            foreach ($rule in $ruleNameGroup.Group)
-                            {
-                                Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
-                            }
-                        }
-
-                        Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+                        Write-PsScriptAnalyzerWarning -PssaRuleOutput $customPssaRulesOutput -RuleType 'Custom DSC Resource Kit'
                     }
 
                     if ($null -ne $customPssaRulesOutput -and (Get-OptInStatus -OptIns $optIns -Name 'Common Tests - Custom Script Analyzer Rules'))

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -434,6 +434,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                         foreach ($errorPssaRuleOutput in $errorPssaRulesOutput)
                         {
+                            Write-Warning -Message "PSSA Rule Name: $($errorPssaRuleOutput.RuleName) "
                             Write-Warning -Message "$($errorPssaRuleOutput.ScriptName) (Line $($errorPssaRuleOutput.Line)): $($errorPssaRuleOutput.Message)"
                         }
 
@@ -453,6 +454,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                         foreach ($requiredPssaRuleOutput in $requiredPssaRulesOutput)
                         {
+                            Write-Warning -Message "PSSA Rule Name: $($requiredPssaRuleOutput.RuleName) "
                             Write-Warning -Message "$($requiredPssaRuleOutput.ScriptName) (Line $($requiredPssaRuleOutput.Line)): $($requiredPssaRuleOutput.Message)"
                         }
 
@@ -479,6 +481,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                         foreach ($flaggedPssaRuleOutput in $flaggedPssaRulesOutput)
                         {
+                            Write-Warning -Message "PSSA Rule Name: $($flaggedPssaRuleOutput.RuleName) "
                             Write-Warning -Message "$($flaggedPssaRuleOutput.ScriptName) (Line $($flaggedPssaRuleOutput.Line)): $($flaggedPssaRuleOutput.Message)"
                         }
 
@@ -507,6 +510,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                         foreach ($newErrorPssaRuleOutput in $newErrorPssaRulesOutput)
                         {
+                            Write-Warning -Message "PSSA Rule Name: $($newErrorPssaRuleOutput.RuleName) "
                             Write-Warning -Message "$($newErrorPssaRuleOutput.ScriptName) (Line $($newErrorPssaRuleOutput.Line)): $($newErrorPssaRuleOutput.Message)"
                         }
 
@@ -555,6 +559,7 @@ Describe 'Common Tests - PS Script Analyzer on Resource Files' {
 
                         foreach ($customPssaRuleOutput in $customPssaRulesOutput)
                         {
+                            Write-Warning -Message "Custom PSSA Rule Name: $($customPssaRuleOutput.RuleName) "
                             Write-Warning -Message "$($customPssaRuleOutput.ScriptName) (Line $($customPssaRuleOutput.Line)): $($customPssaRuleOutput.Message)"
                         }
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,8 @@ This branch is used by DSC Resource Kit modules for running common tests.
 - [Documentation Helper Module](#documentation-helper-module)
 - [Run integration tests in order](#run-integration-tests-in-order)
   - [Run tests in a Docker Windows container](#run-tests-in-a-docker-windows-container)
-    - [Named attribute argument](#named-attribute-argument)
-    - [Example](#example)
-    - [Artifacts when running tests in a container](#artifacts-when-running-tests-in-a-container)
 - [Deploy](#deploy)
   - [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)
-    - [Requirements/dependencies for publishing to PowerShell Gallery](#requirementsdependencies-for-publishing-to-powershell-gallery)
-    - [PowerShell Gallery API key](#powershell-gallery-api-key)
-    - [Contributor responsibilities](#contributor-responsibilities)
 - [Versions](#versions)
   - [Unreleased](#unreleased)
   - [0.2.0.0](#0200)
@@ -199,7 +193,7 @@ function Get-TargetResource
 }
 ```
 
-To suppress the **Measure-ParameterBlockParameterAttribute** in this example, this can be dome by using the SuppressMessageAttribute like this:
+To suppress the **Measure-ParameterBlockParameterAttribute** in this example, this can be done by using the SuppressMessageAttribute like this:
 
 ```powershell
 function Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For example, the following code would cause the **PSAvoidGlobalVars** built-in P
 ```powerShell
 function Set-TargetResource
 {
-    Param
+    param
     (
         [Parameter(Mandatory = $true)]
         [String]
@@ -206,7 +206,7 @@ To suppress the **PSAvoidGlobalVars** rule for this function, this can be done b
 function Set-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
-    Param
+    param
     (
         [Parameter(Mandatory = $true)]
         [String]

--- a/README.md
+++ b/README.md
@@ -27,52 +27,45 @@ as pull requests.
 This branch is used by DSC Resource Kit modules for running common tests.
 
 ## Table of Contents
+
 <!-- TOC -->
 
-- [DscResource.Tests](#dscresourcetests)
-    - [Branches](#branches)
-        - [master](#master)
-        - [dev](#dev)
-    - [Table of Contents](#table-of-contents)
-    - [DSC Resource Common Meta Tests](#dsc-resource-common-meta-tests)
-        - [Goals](#goals)
-        - [Git and Unicode](#git-and-unicode)
-        - [Markdown Testing](#markdown-testing)
-        - [Example Testing](#example-testing)
-        - [PSScriptAnalyzer Rules](#psscriptanalyzer-rules)
-    - [MetaFixers Module](#metafixers-module)
-    - [TestHelper Module](#testhelper-module)
-    - [Templates for Creating Tests](#templates-for-creating-tests)
-    - [Example Test Usage](#example-test-usage)
-    - [Example Usage of DSCResource.Tests in AppVeyor.yml](#example-usage-of-dscresourcetests-in-appveyoryml)
-    - [AppVeyor Module](#appveyor-module)
-        - [Phased Meta test Opt-In](#phased-meta-test-opt-in)
-        - [Using AppVeyor.psm1 with the default shared model](#using-appveyorpsm1-with-the-default-shared-model)
-        - [Using AppVeyor.psm1 with harness model](#using-appveyorpsm1-with-harness-model)
-    - [Encrypt Credentials in Integration Tests](#encrypt-credentials-in-integration-tests)
-    - [CodeCoverage reporting with CodeCov.io](#codecoverage-reporting-with-codecovio)
-        - [Ensure Code Coverage is enabled](#ensure-code-coverage-is-enabled)
-            - [Repository using `-Type 'Default'` for `Invoke-AppveyorTestScriptTask`](#repository-using--type-default-for-invoke-appveyortestscripttask)
-            - [Repository using `-Type 'Harness'` for `Invoke-AppveyorTestScriptTask`](#repository-using--type-harness-for-invoke-appveyortestscripttask)
-        - [Enable reporting to CodeCove.io](#enable-reporting-to-codecoveio)
-        - [Configure CodeCov.io](#configure-codecovio)
-        - [Add the badge to the Readme](#add-the-badge-to-the-readme)
-    - [Documentation Helper Module](#documentation-helper-module)
-    - [Run integration tests in order](#run-integration-tests-in-order)
-        - [Run tests in a Docker Windows container](#run-tests-in-a-docker-windows-container)
-            - [Named attribute argument](#named-attribute-argument)
-            - [Example](#example)
-            - [Artifacts when running tests in a container](#artifacts-when-running-tests-in-a-container)
-    - [Deploy](#deploy)
-        - [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)
-            - [Requirements/dependencies for publishing to PowerShell Gallery](#requirementsdependencies-for-publishing-to-powershell-gallery)
-            - [PowerShell Gallery API key](#powershell-gallery-api-key)
-            - [Contributor responsibilities](#contributor-responsibilities)
-                - [Example of script metadata, #Requires statement and comment-based help](#example-of-script-metadata-requires-statement-and-comment-based-help)
-    - [Versions](#versions)
-        - [Unreleased](#unreleased)
-        - [0.2.0.0](#0200)
-        - [0.1.0.0](#0100)
+- [DSC Resource Common Meta Tests](#dsc-resource-common-meta-tests)
+  - [Goals](#goals)
+  - [Git and Unicode](#git-and-unicode)
+  - [Markdown Testing](#markdown-testing)
+  - [Example Testing](#example-testing)
+  - [PSScriptAnalyzer Rules](#psscriptanalyzer-rules)
+- [MetaFixers Module](#metafixers-module)
+- [TestHelper Module](#testhelper-module)
+- [Templates for Creating Tests](#templates-for-creating-tests)
+- [Example Test Usage](#example-test-usage)
+- [Example Usage of DSCResource.Tests in AppVeyor.yml](#example-usage-of-dscresourcetests-in-appveyoryml)
+- [AppVeyor Module](#appveyor-module)
+  - [Phased Meta test Opt-In](#phased-meta-test-opt-in)
+  - [Using AppVeyor.psm1 with the default shared model](#using-appveyorpsm1-with-the-default-shared-model)
+  - [Using AppVeyor.psm1 with harness model](#using-appveyorpsm1-with-harness-model)
+- [Encrypt Credentials in Integration Tests](#encrypt-credentials-in-integration-tests)
+- [CodeCoverage reporting with CodeCov.io](#codecoverage-reporting-with-codecovio)
+  - [Ensure Code Coverage is enabled](#ensure-code-coverage-is-enabled)
+  - [Enable reporting to CodeCove.io](#enable-reporting-to-codecoveio)
+  - [Configure CodeCov.io](#configure-codecovio)
+  - [Add the badge to the Readme](#add-the-badge-to-the-readme)
+- [Documentation Helper Module](#documentation-helper-module)
+- [Run integration tests in order](#run-integration-tests-in-order)
+  - [Run tests in a Docker Windows container](#run-tests-in-a-docker-windows-container)
+    - [Named attribute argument](#named-attribute-argument)
+    - [Example](#example)
+    - [Artifacts when running tests in a container](#artifacts-when-running-tests-in-a-container)
+- [Deploy](#deploy)
+  - [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)
+    - [Requirements/dependencies for publishing to PowerShell Gallery](#requirementsdependencies-for-publishing-to-powershell-gallery)
+    - [PowerShell Gallery API key](#powershell-gallery-api-key)
+    - [Contributor responsibilities](#contributor-responsibilities)
+- [Versions](#versions)
+  - [Unreleased](#unreleased)
+  - [0.2.0.0](#0200)
+  - [0.1.0.0](#0100)
 
 <!-- /TOC -->
 
@@ -207,6 +200,7 @@ function Get-TargetResource
 ```
 
 To suppress the **Measure-ParameterBlockParameterAttribute** in this example, this can be dome by using the SuppressMessageAttribute like this:
+
 ```powershell
 function Get-TargetResource
 {
@@ -238,12 +232,12 @@ fails, you should be able to run `ConvertTo-UTF8` fixer from [MetaFixers.psm1](M
 
 The test helper module (TestHelper.psm1) contains the following functions:
 
-* **New-Nuspec**: Creates a new nuspec file for nuget package.
-* **Install-ResourceDesigner**: Will attempt to download the
+- **New-Nuspec**: Creates a new nuspec file for nuget package.
+- **Install-ResourceDesigner**: Will attempt to download the
   xDSCResourceDesignerModule using Nuget package and return the module.
-* **Initialize-TestEnvironment**: Initializes an environment for running unit or
+- **Initialize-TestEnvironment**: Initializes an environment for running unit or
   integration tests on a DSC resource.
-* **Restore-TestEnvironment**: Restores the environment after running unit or
+- **Restore-TestEnvironment**: Restores the environment after running unit or
   integration tests on a DSC resource.
 
 ## Templates for Creating Tests
@@ -257,11 +251,11 @@ document and the instructions at the top of each template file.
 
 The resource files are:
 
-* **[Unit_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/unit_template.ps1)**:
+- **[Unit_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/unit_template.ps1)**:
   Use to create a set of Unit Pester tests for a single DSC Resource.
-* **[Integration_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/integration_template.ps1)**:
+- **[Integration_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/integration_template.ps1)**:
   Use to create a set of Integration Pester tests for a single DSC Resource.
-* **[Integration_Config_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/unit_template.ps1)**:
+- **[Integration_Config_Template.ps1](https://github.com/PowerShell/DscResources/blob/master/Tests.Template/unit_template.ps1)**:
   Use to create a DSC Configuration file for a single DSC Resource. Used in
   conjunction with Integration_Template.ps1.
 
@@ -287,25 +281,25 @@ This module provides functions for building and testing DSC Resources in AppVeyo
 
 >Note: These functions will only work if called within an AppVeyor CI build task.
 
-* **Invoke-AppveyorInstallTask**: This task is used to set up the environment in
+- **Invoke-AppveyorInstallTask**: This task is used to set up the environment in
   preparation for the test and deploy tasks.
   It should be called under the install AppVeyor phase (the `install:` keyword in
   the *appveyor.yml*).
-* **Invoke-AppveyorTestScriptTask**: This task is used to execute the tests.
+- **Invoke-AppveyorTestScriptTask**: This task is used to execute the tests.
   It should be called under test AppVeyor phase (the `test_script:` keyword in
   the *appveyor.yml*).
-* **Invoke-AppveyorAfterTestTask**: This task is used to perform the following tasks.
+- **Invoke-AppveyorAfterTestTask**: This task is used to perform the following tasks.
   It should be called either under the test AppVeyor phase (the `test_script:`
   keyword in the *appveyor.yml*), or the after tests AppVeyor phase (the `after_test:`
   keyword in the *appveyor.yml*).
-  * Generate, zip and publish the Wiki content to AppVeyor (optional).
-  * Set the build number in the DSC Resource Module manifest.
-  * Publish the Test Results artefact to AppVeyor.
-  * Zip and publish the DSC Resource content to AppVeyor.
-* **Invoke-AppVeyorDeployTask**: This task is used to perform the following tasks.
+  - Generate, zip and publish the Wiki content to AppVeyor (optional).
+  - Set the build number in the DSC Resource Module manifest.
+  - Publish the Test Results artefact to AppVeyor.
+  - Zip and publish the DSC Resource content to AppVeyor.
+- **Invoke-AppVeyorDeployTask**: This task is used to perform the following tasks.
   It should be called under the deploy AppVeyor phase (the `deploy_script:`
   keyword in the *appveyor.yml*).
-  * [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)).
+  - [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)).
 
 ### Phased Meta test Opt-In
 
@@ -315,26 +309,26 @@ any new problem in the area, this will cause the tests to fail, not just warn.
 
 The following opt-in flags are available:
 
-* **Common Tests - Validate Module Files**: run tests to validate module files
+- **Common Tests - Validate Module Files**: run tests to validate module files
   have correct BOM.
-* **Common Tests - Validate Markdown Files**: run tests to validate markdown
+- **Common Tests - Validate Markdown Files**: run tests to validate markdown
   files do not violate markdown rules. Markdown rules can be suppressed in
   .markdownlint.json file.
-* **Common Tests - Validate Example Files**: run tests to validate that examples
+- **Common Tests - Validate Example Files**: run tests to validate that examples
   can be compiled without error.
-* **Common Tests - Validate Example Files To Be Published**: run tests to
+- **Common Tests - Validate Example Files To Be Published**: run tests to
   validate that examples can be published successfully to PowerShell Gallery.
   See requirements under
   [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery).
-* **Common Tests - Validate Script Files**: run tests to validate script files
+- **Common Tests - Validate Script Files**: run tests to validate script files
   have correct BOM.
-* **Common Tests - Required Script Analyzer Rules**: fail tests if any required
+- **Common Tests - Required Script Analyzer Rules**: fail tests if any required
   script analyzer rules are violated.
-* **Common Tests - Flagged Script Analyzer Rules**: fail tests if any flagged
+- **Common Tests - Flagged Script Analyzer Rules**: fail tests if any flagged
   script analyzer rules are violated.
-* **Common Tests - New Error-Level Script Analyzer Rules**: fail tests if any
+- **Common Tests - New Error-Level Script Analyzer Rules**: fail tests if any
   new error-level script analyzer rules are violated.
-* **Common Tests - Custom Script Analyzer Rules**: fail tests if any
+- **Common Tests - Custom Script Analyzer Rules**: fail tests if any
   custom script analyzer rules are violated.
 
 ### Using AppVeyor.psm1 with the default shared model
@@ -535,9 +529,9 @@ an exception will be thrown which will stop the the tests in the build worker.
 
 #### Named attribute argument
 
-* **ContainerName**: The name of the container. If the same container name is used
+- **ContainerName**: The name of the container. If the same container name is used
   in multiple tests they will be run sequentially in the same container.
-* **ContainerImage**: The name of the container image to use for the container.
+- **ContainerImage**: The name of the container image to use for the container.
   This should use the normal Docker format for specifying a Docker image, i.e.
   'microsoft/windowsservercore:latest'. If the tag 'latest' is used, then
   `docker pull` will always run to make sure the latest revision of the image is
@@ -580,18 +574,18 @@ param()
 
 These are the artifacts that differ when running tests using a container.
 
-* unittest_Transcript.txt - Contains the transcript from the test run that
+- unittest_Transcript.txt - Contains the transcript from the test run that
   was done in the container.
-* unittest_TestResults.xml - Contains the Pester output in the NUnitXML
+- unittest_TestResults.xml - Contains the Pester output in the NUnitXML
   format from the tests that was tested in the container.
-* unittest_TestResults.json - Contains the serialized object that Pester
+- unittest_TestResults.json - Contains the serialized object that Pester
   returned after it finished the test run in the container.
-* unittest_DockerLog.txt - If the container exits with any other exit code
+- unittest_DockerLog.txt - If the container exits with any other exit code
   than 0 a Docker log is gathered and uploaded as an artifact. This is
   intended to enable a more detailed view of the error.
   If the container exits with exit code 0 then the Docker log will *not* be
   uploaded.
-* worker_TestsResults - Contains the Pester output in the NUnitXML format
+- worker_TestsResults - Contains the Pester output in the NUnitXML format
   from the tests that was tested in the build worker.
 
 ## Deploy
@@ -627,25 +621,25 @@ deploy tasks in the appveyor.yml).
 
 #### Requirements/dependencies for publishing to PowerShell Gallery
 
-* Publish only on 'master' build.
-* Must have opt-in for the example validation common test.
-* Publish only an example that passes `Test-ScriptFileInfo`.
-* Publish only an example that does not already exist (for example has a newer
+- Publish only on 'master' build.
+- Must have opt-in for the example validation common test.
+- Publish only an example that passes `Test-ScriptFileInfo`.
+- Publish only an example that does not already exist (for example has a newer
   version).
-* Publish only an example which is located under '\Examples' folder.
-* Publish only an example where file name ends with 'Config'.
-* Publish only an example that where filename and configuration name are the same.
+- Publish only an example which is located under '\Examples' folder.
+- Publish only an example where file name ends with 'Config'.
+- Publish only an example that where filename and configuration name are the same.
   *Published examples must have the same configuration name as the file name to
   be able to deploy in Azure Automation.*
-  * Example files are allowed to begin, be prefixed, with numeric value followed
+  - Example files are allowed to begin, be prefixed, with numeric value followed
     by a dash (e.g. '1-', '2-') to support auto-documentation. The prefix will
     be removed from the name when publishing, so the filename will appear without
     the prefix in PowerShell Gallery.
-* Publish only examples that have a unique GUID within the resource module.
+- Publish only examples that have a unique GUID within the resource module.
   *Note: This is only validated within the resource module, the validation
   does not validate this against PowerShell Gallery. This is to prevent
   simple copy/paste mistakes within the same resource module.*
-* Publish only an example where the configuration name contains only letters,
+- Publish only an example where the configuration name contains only letters,
   numbers, and underscores. Where the name starts with a letter, and ends with a
   letter or a number.
 
@@ -681,18 +675,18 @@ environment:
 
 Contributors that add or change an example to be published must make sure that
 
-* The example filename is short but descriptive and ends with 'Config'.
-  * If the example is for a single resource, then the resource name could be
+- The example filename is short but descriptive and ends with 'Config'.
+  - If the example is for a single resource, then the resource name could be
     prefixed in the filename (and configuration name) followed by an underscore
     (e.g. xScript_WatchFileContentConfig.ps1). *The thought is to easier find
     related examples.*
-* The `Node` block is targeting 'localhost' (or equivalent).
-* The filename and configuration name match (see requirements/dependencies above).
-* The example contains script metadata with all required properties present.
-* The example has an unique GUID in the script metadata.
-* The example have comment-based help with at least `.DESCRIPTION`.
-* The example script metadata version and release notes is updated accordingly.
-* (Optional) The example has a `#Requires` statement.
+- The `Node` block is targeting 'localhost' (or equivalent).
+- The filename and configuration name match (see requirements/dependencies above).
+- The example contains script metadata with all required properties present.
+- The example has an unique GUID in the script metadata.
+- The example have comment-based help with at least `.DESCRIPTION`.
+- The example script metadata version and release notes is updated accordingly.
+- (Optional) The example has a `#Requires` statement.
 
 ##### Example of script metadata, #Requires statement and comment-based help
 
@@ -741,188 +735,186 @@ Contributors that add or change an example to be published must make sure that
 
 ### Unreleased
 
-* Added Rule Name to PS Script Analyzer custom rules
-* Added PsScript Analyzer Rule Name to Write-Warning output in meta.tests
-* Extra whitespace trimmed from TestHelper.psm1 (feature of VS Code).
-* Removed code to Remove-Module from Initialize-TestEnvironment because not
+- Extra whitespace trimmed from TestHelper.psm1 (feature of VS Code).
+- Removed code to Remove-Module from Initialize-TestEnvironment because not
   required: Import-Module -force should do the same thing.
-* Initialize-TestEnvironment changed to import module being tested into Global
+- Initialize-TestEnvironment changed to import module being tested into Global
   scope so that InModuleScope not required in tests.
-* Fixed aliases in files
-* Initialize-TestEnvironment changed to update the execution policy for the
+- Fixed aliases in files
+- Initialize-TestEnvironment changed to update the execution policy for the
   current process only
-* Restore-TestEnvironment changed to update the execution policy for the
+- Restore-TestEnvironment changed to update the execution policy for the
   current process only.
-* Cleaned all common tests
-  * Added tests for PS Script Analyzer
-* Cleaned TestHelper
-  * Removed Force parameter from Install-ModuleFromPowerShellGallery
-  * Added more test helper functions
-* Cleaned MetaFixers and TestRunner
-* Updated common test output format
-* Added ```Install-NugetExe``` to TestHelper.psm1
-* Fixed up Readme.md to remove markdown violations and resolve duplicate information
-* Added ```AppVeyor.psm1``` module
-* Added ```DscResource.DocumentationHelper``` modules
-* Added new tests for testing Examples and Markdown (using Node/NPM/Gulp)
-* Clean up layout of Readme.md to be more logically structured and added more information
+- Cleaned all common tests
+  - Added tests for PS Script Analyzer
+- Cleaned TestHelper
+  - Removed Force parameter from Install-ModuleFromPowerShellGallery
+  - Added more test helper functions
+- Cleaned MetaFixers and TestRunner
+- Updated common test output format
+- Added ```Install-NugetExe``` to TestHelper.psm1
+- Fixed up Readme.md to remove markdown violations and resolve duplicate information
+- Added ```AppVeyor.psm1``` module
+- Added ```DscResource.DocumentationHelper``` modules
+- Added new tests for testing Examples and Markdown (using Node/NPM/Gulp)
+- Clean up layout of Readme.md to be more logically structured and added more information
   about the new tests and modules
-* Added documentation for new tests and features
-* Added phased Meta Test roll-out
-* Added code coverage report with [codecov.io](http://codecove.io)
-* Added default parameter values for HarnessFunctionName and HarnessModulePath in AppVeyor\Invoke-AppveyorTestScriptTask cmdlet
-* Fixed bug in DscResource.DocumentationHelper\MofHelper.psm1 when 'class' mentioned in MOF file outside of header
-* Added ability for DscResource.DocumentationHelper\WikiPages.psm1 to display Array type parameters correctly
-* Fixed Wiki Generation to create Markdown that does not violate markdown rules
-* Removed violation of markdown rules from Readme.md
-* Fixed Wiki Generation when Example header contains parentheses.
-* Added so that any error message for each test are also published to the AppVeyor "Tests-view".
-* Added a common test to verify so that no markdown files contains Byte Order Mark (BOM) (issue #108).
-* Fixed bug where node_modules or .git directories caused errors with long file
+- Added documentation for new tests and features
+- Added phased Meta Test roll-out
+- Added code coverage report with [codecov.io](http://codecove.io)
+- Added default parameter values for HarnessFunctionName and HarnessModulePath in AppVeyor\Invoke-AppveyorTestScriptTask cmdlet
+- Fixed bug in DscResource.DocumentationHelper\MofHelper.psm1 when 'class' mentioned in MOF file outside of header
+- Added ability for DscResource.DocumentationHelper\WikiPages.psm1 to display Array type parameters correctly
+- Fixed Wiki Generation to create Markdown that does not violate markdown rules
+- Removed violation of markdown rules from Readme.md
+- Fixed Wiki Generation when Example header contains parentheses.
+- Added so that any error message for each test are also published to the AppVeyor "Tests-view".
+- Added a common test to verify so that no markdown files contains Byte Order Mark (BOM) (issue #108).
+- Fixed bug where node_modules or .git directories caused errors with long file
   paths for tests
-* Added SkipPublisherCheck to Install-Module calls for installing Pester.
+- Added SkipPublisherCheck to Install-Module calls for installing Pester.
   This way it does not conflict with signed Pester module included in Windows.
-  * Fixed bug when SkipPublisherCheck does not exist in older versions of the
+  - Fixed bug when SkipPublisherCheck does not exist in older versions of the
     Install-Module cmdlet.
-* Changed so that markdown lint rules MD013 and MD024 is disabled by default for the markdown common test.
-* Added an option to use a markdown lint settings file in the repository which will
+- Changed so that markdown lint rules MD013 and MD024 is disabled by default for the markdown common test.
+- Added an option to use a markdown lint settings file in the repository which will
   override the default markdown lint settings file in DscResource.Tests repository.
-* Added a new parameter ResourceType to the test helper function Initialize-TestEnvironment
+- Added a new parameter ResourceType to the test helper function Initialize-TestEnvironment
   to be able to test class-based resources in the folder DscClassResources.
   The new parameter ResourceType can be set to either 'Mof' or 'Class'.
   Default value for parameter ResourceType is 'Mof'.
-* Changed markdown lint rule MD029 to use the 'one' style for ordered lists (issue #115).
-* Removed the reference to the function ConvertTo-SpaceIndentation from the warning
+- Changed markdown lint rule MD029 to use the 'one' style for ordered lists (issue #115).
+- Removed the reference to the function ConvertTo-SpaceIndentation from the warning
   message in the test that checks for tabs in module files. The function
   ConvertTo-SpaceIndentation does not exist anymore ([issue #4](https://github.com/PowerShell/DscResource.Tests/issues/4)).
-* Removed Byte Order Mark (BOM) from the module file TestRunner.psm1.
-* Updated so that checking for Byte Order Mark (BOM) in markdown file lists the
+- Removed Byte Order Mark (BOM) from the module file TestRunner.psm1.
+- Updated so that checking for Byte Order Mark (BOM) in markdown file lists the
   full path so it easier to distinguish when filenames are equal in different
   locations.
-* Updated so that module files (.psm1) are checked for Byte Order Mark (BOM)
+- Updated so that module files (.psm1) are checked for Byte Order Mark (BOM)
   (issue #143).
-* Updated It-blocks for File Parsing tests so that they are more descriptive for
+- Updated It-blocks for File Parsing tests so that they are more descriptive for
   the AppVeyor "Tests-view".
-* Changed debug message which outputs the type of the $results variable (in
+- Changed debug message which outputs the type of the $results variable (in
   AppVeyor.psm1) to use Write-Verbose instead of Write-Info ([issue #99](https://github.com/PowerShell/DscResource.Tests/issues/99)).
-* Added `Get-ResourceModulesInConfiguration` to `TestHelper.psm1` to get support installing
+- Added `Get-ResourceModulesInConfiguration` to `TestHelper.psm1` to get support installing
   DSC Resource modules when testing examples.
-* Enable 'Common Tests - Validate Example Files' to install missing required modules if
+- Enable 'Common Tests - Validate Example Files' to install missing required modules if
   running in AppVeyor or show warning if run by user.
-* Added new common test so that script files (.ps1) are checked for Byte Order
+- Added new common test so that script files (.ps1) are checked for Byte Order
   Mark (BOM) ([issue #160](https://github.com/PowerShell/DscResource.Tests/issues/160)).
   This test is opt-in using .MetaTestOptIn.json.
-* Added minimum viable product for applying custom PSSA rules to check adherence to
+- Added minimum viable product for applying custom PSSA rules to check adherence to
   DSC Resource Kit style guidelines ([issue #86](https://github.com/PowerShell/DscResource.Tests/issues/86)).
   The current rules checks the [Parameter()] attribute format is correct in all parameter blocks.
-  * Fixed Byte Order Mark (BOM) in files; DscResource.AnalyzerRules.psd1,
+  - Fixed Byte Order Mark (BOM) in files; DscResource.AnalyzerRules.psd1,
   DscResource.AnalyzerRules.psm1 and en-US/DscResource.AnalyzerRules.psd1
   ([issue #169](https://github.com/PowerShell/DscResource.Tests/issues/169)).
-  * Extended the parameter custom rule to also validate the Mandatory attribute.
-* Fixed so that code coverage can be scan for code even if there is no DSCResource
+  - Extended the parameter custom rule to also validate the Mandatory attribute.
+- Fixed so that code coverage can be scan for code even if there is no DSCResource
   folder.
-* Added workaround for AppVeyor replaces punctuation in folder structure for
+- Added workaround for AppVeyor replaces punctuation in folder structure for
   DscResource.Tests.
-* Remove the $repoName variable and replace it with $moduleName as it was a
+- Remove the $repoName variable and replace it with $moduleName as it was a
   duplicate.
-* Added so that DscResource.Tests is testing it self with it's own common tests
+- Added so that DscResource.Tests is testing it self with it's own common tests
   ([issue #170](https://github.com/PowerShell/DscResource.Tests/issues/170)).
-* Change README.md to resolve lint error MD029 and MD036.
-* Added module manifest for manifest common tests to pass.
-* Added status badges to README.md.
-* Fixed the markdown test so that node_modules can be deleted when path contains
+- Change README.md to resolve lint error MD029 and MD036.
+- Added module manifest for manifest common tests to pass.
+- Added status badges to README.md.
+- Fixed the markdown test so that node_modules can be deleted when path contains
   an apostrophe ([issue #166](https://github.com/PowerShell/DscResource.Tests/issues/166)).
-  * Fixed typo in It-blocks when uninstalling dependencies.
-* Code was moved from the example tests into a new helper function Install-DependentModule
+  - Fixed typo in It-blocks when uninstalling dependencies.
+- Code was moved from the example tests into a new helper function Install-DependentModule
   ([issue #168](https://github.com/PowerShell/DscResource.Tests/issues/168)).
   Also fixed bug with Version, where Install-Module would not use the correct
   variable for splatting.
-* Enable so that missing required modules for integration tests is installed if
+- Enable so that missing required modules for integration tests is installed if
   running in AppVeyor or show warning if run by user ([issue #168](https://github.com/PowerShell/DscResource.Tests/issues/168)).
-* Set registry key HKLM:\Software\Microsoft\PowerShell\DisablePromptToUpdateHelp
+- Set registry key HKLM:\Software\Microsoft\PowerShell\DisablePromptToUpdateHelp
   to 1 when running in AppVeyor to suppress warning caused by running custom rules
   in PSScriptAnalyzer in the GetExternalRule() method of `Engine/ScriptAnalyzer.cs`
   ([issue #176](https://github.com/PowerShell/DscResource.Tests/issues/176)).
-* Added unit tests for helper function Start-DscResourceTests.
-* Updated AppVeyor code so that common tests and unit tests is run on the working
+- Added unit tests for helper function Start-DscResourceTests.
+- Updated AppVeyor code so that common tests and unit tests is run on the working
   branch's tests. This is to be able to test changes to tests in pull requests
   without having to merge the pull request before seeing the result.
-* Add opt-in parameter RunTestInOrder for the helper function Invoke-AppveyorTestScriptTask
+- Add opt-in parameter RunTestInOrder for the helper function Invoke-AppveyorTestScriptTask
   which enables running integration tests in order ([issue #184](https://github.com/PowerShell/DscResource.Tests/issues/184)).
-  * Refactored the class IntegrationTest to be a public sealed class and using
+  - Refactored the class IntegrationTest to be a public sealed class and using
     a named property for OrderNumber
     ([issue #191](https://github.com/PowerShell/DscResource.Tests/issues/191)).
-* Add Script Analyzer custom rule to test functions and statements so that
+- Add Script Analyzer custom rule to test functions and statements so that
   opening braces are set according to the style guideline ([issue #27](https://github.com/PowerShell/DscResource.Tests/issues/27)).
-* When common tests are running on another repository than DscResource.Tests the
+- When common tests are running on another repository than DscResource.Tests the
   DscResource.Tests unit and integration tests are removed from the list of tests
   to run ([issue #189](https://github.com/PowerShell/DscResource.Tests/issues/189)).
-* Fix ModuleVersion number value inserted into manifest in Nuget package produced
+- Fix ModuleVersion number value inserted into manifest in Nuget package produced
   in Invoke-AppveyorAfterTestTask ([issue #193](https://github.com/PowerShell/DscResource.Tests/issues/193)).
-* Fix TestRunner.Tests.ps1 to make compatible with Pester 4.0.7 ([issue #196](https://github.com/PowerShell/DscResource.Tests/issues/196)).
-* Improved WikiPages.psm1 to include the EmbeddedInstance to the datatype in the
+- Fix TestRunner.Tests.ps1 to make compatible with Pester 4.0.7 ([issue #196](https://github.com/PowerShell/DscResource.Tests/issues/196)).
+- Improved WikiPages.psm1 to include the EmbeddedInstance to the datatype in the
   generated wiki page ([issue #201](https://github.com/PowerShell/DscResource.Tests/issues/201))
-* Added basic support for analyzing TypeDefinitionAst related code e.g. Enum & Class definitions to include
+- Added basic support for analyzing TypeDefinitionAst related code e.g. Enum & Class definitions to include
   Basic Brace newline rules
-  * Created new unit tests to validate the Analyzer rules pass or fail as expected for these new rules
-* Added Test-IsClass Cmdlet to determine if particular Ast objects are members of a Class or not
-  * Created new Unit Tests to validate the functionality of said cmdlet
-* Modified current Parameter, and AttributeArgument Analyzer Rules to check for Class membership and properly validate in those cases as well as the current Function based Cmdlets
-  * Created new unit tests to validate the new Analyzer rules pass or fail as expected for Class based resources
-* Minor code cleanup in AppVeyor.psm1.
-* Updated documentation in README.md and comment-based help in TestHelp.psm1 to
+  - Created new unit tests to validate the Analyzer rules pass or fail as expected for these new rules
+- Added Test-IsClass Cmdlet to determine if particular Ast objects are members of a Class or not
+  - Created new Unit Tests to validate the functionality of said cmdlet
+- Modified current Parameter, and AttributeArgument Analyzer Rules to check for Class membership and properly validate in those cases as well as the current Function based Cmdlets
+  - Created new unit tests to validate the new Analyzer rules pass or fail as expected for Class based resources
+- Minor code cleanup in AppVeyor.psm1.
+- Updated documentation in README.md and comment-based help in TestHelp.psm1 to
   use the new name of the renamed SqlServerDsc resource module.
-* Fixed minor typo in manifest for the CodeCoverage module.
-* Added a wrapper Set-PSModulePath for setting $env:PSModulePath to be able to
+- Fixed minor typo in manifest for the CodeCoverage module.
+- Added a wrapper Set-PSModulePath for setting $env:PSModulePath to be able to
   write unit tests for the helper functions with more code coverage.
-* Minor typos and cleanup in helper functions.
-* Fixed a bug in Install-DependentModule when calling the helper function using
+- Minor typos and cleanup in helper functions.
+- Fixed a bug in Install-DependentModule when calling the helper function using
   a specific version to install. Now Get-Module will no longer throw an error
   that it does not have a parameter named 'Version'.
-* Added unit test for helper function in TestHelper to increase code coverage.
-* Added Invoke-AppveyorTestScriptTask cmdlet functionality for CodeCoverage for Class based resources ([issue #173](https://github.com/PowerShell/DscResource.Tests/issues/173))
-* Add opt-in parameter RunInContainer for the helper function Invoke-AppveyorTestScriptTask
+- Added unit test for helper function in TestHelper to increase code coverage.
+- Added Invoke-AppveyorTestScriptTask cmdlet functionality for CodeCoverage for Class based resources ([issue #173](https://github.com/PowerShell/DscResource.Tests/issues/173))
+- Add opt-in parameter RunInContainer for the helper function Invoke-AppveyorTestScriptTask
   which enables running unit tests in a Docker Windows container. The RunInContainer
   parameter can only be used when the parameter RunTestInOrder is also used.
-* Moved helper function Write-Info to the TestHelpers module so it could be reused
+- Moved helper function Write-Info to the TestHelpers module so it could be reused
   by other modules. The string was changed to output 'UTC' before the time to
   clarify that it is UTC time, and optional parameter 'ForegroundColor' was added
   so that it is possible to change the color of the text that is written.
-* Added module DscResource.Container which contain logic to handle the container
+- Added module DscResource.Container which contain logic to handle the container
   testing when unit tests are run in a Docker Windows container.
-* Added Get-OptInStatus function to enable retrieving of an opt-in status
+- Added Get-OptInStatus function to enable retrieving of an opt-in status
   by name. This is required for implementation of PSSA opt-in rules where
   the describe block contains multiple opt-ins in a single block.
-* Added new opt-in flags to allow enforcement of script analyzer rules ([issue #161](https://github.com/PowerShell/DscResource.Tests/issues/161))
-* Updated year in DscResources.Tests.psd1 manifest to 2018.
-* Fixed bug where common test would throw an error if there were no
+- Added new opt-in flags to allow enforcement of script analyzer rules ([issue #161](https://github.com/PowerShell/DscResource.Tests/issues/161))
+- Updated year in DscResources.Tests.psd1 manifest to 2018.
+- Fixed bug where common test would throw an error if there were no
   .MetaTestOptIn.json file or it was empty (no opt-ins).
-* Added more tests for custom Script Analazyer rules to increased code coverage.
+- Added more tests for custom Script Analazyer rules to increased code coverage.
   These new tests call the Measure-functions directly.
-* Changed so that DscResource.Tests repository can analyze code coverage for the
+- Changed so that DscResource.Tests repository can analyze code coverage for the
   helper modules ([issue #208](https://github.com/PowerShell/DscResource.Tests/issues/208)).
-* Importing of the TestHelper.psm1 module is now done at the top of the script of
+- Importing of the TestHelper.psm1 module is now done at the top of the script of
   AppVeyor.psm1. Previously it was imported in each helper function. This was done
   to make it easier to mock the helper functions inside the TestHelper.psm1 module
   when testing AppVeyor.psm1.
-* Changed Get-PSModulePathItem to trim end back slash ([issue #217](https://github.com/PowerShell/DscResource.Tests/issues/217))
-* Updated to support running unit tests on PowerShell Core:
-  * Updated helper function Test-FileHasByteOrderMark to use `AsByteStream`.
-  * Install-PackageProvider will only run if `Find-PackageProvider -Name 'Nuget'`
+- Changed Get-PSModulePathItem to trim end back slash ([issue #217](https://github.com/PowerShell/DscResource.Tests/issues/217))
+- Updated to support running unit tests on PowerShell Core:
+  - Updated helper function Test-FileHasByteOrderMark to use `AsByteStream`.
+  - Install-PackageProvider will only run if `Find-PackageProvider -Name 'Nuget'`
     returns a package. Currently it is not found on the AppVeyor build worker for
     PowerShell Core.
-  * Adding tests to AppVeyor test pane is done by using the RestAPI because the
+  - Adding tests to AppVeyor test pane is done by using the RestAPI because the
     cmdlet Add-AppveyorTest is not supported on PowerShell Core yet.
-  * All Push-AppveyorArtifact has been changed to use the helper function
+  - All Push-AppveyorArtifact has been changed to use the helper function
     Push-TestArtifact instead.
-  * The helper function Push-TestArtifact uses 'appveyor.exe' to upload
+  - The helper function Push-TestArtifact uses 'appveyor.exe' to upload
     artifacts because the cmdlet Push-AppveyorArtifact is not supported on
     PowerShell Core.
-* Fix codecov no longer generates an error message when uploading test coverage
+- Fix codecov no longer generates an error message when uploading test coverage
   ([issue #203](https://github.com/PowerShell/DscResource.Tests/issues/203)).
-* Added new helper function Get-DscTestContainerInformation to read the container
+- Added new helper function Get-DscTestContainerInformation to read the container
   information in a particular PowerShell script test file (.Tests.ps1).
-* BREAKING CHANGE: For those repositories that are using parameter `RunTestInOrder`
+- BREAKING CHANGE: For those repositories that are using parameter `RunTestInOrder`
   for the helper function `Invoke-AppveyorTestScriptTask` the
   decoration `[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 1)]` need
   to move from the configuration file to the test file. This was done since unit
@@ -930,102 +922,104 @@ Contributors that add or change an example to be published must make sure that
   define the order and the container information using the same decoration.
   It is also natural to have the decoration in the test files since those are
   the scripts that are actually run in order.
-* BREAKING CHANGE: The parameter `RunInDocker` is removed in helper function
+- BREAKING CHANGE: The parameter `RunInDocker` is removed in helper function
   `Invoke-AppveyorTestScriptTask`. Using parameter `RunTestInOrder` will now
   handle running tests in a container, but only if at least on test is decorated
   using `[Microsoft.DscResourceKit.IntegrationTest()]` or
   `[Microsoft.DscResourceKit.UnitTest()]`, together with the correct named arguments.
-* Added support for the default shared module to run unit test and integration test
+- Added support for the default shared module to run unit test and integration test
   in a container by decorating each test file with either
   `[Microsoft.DscResourceKit.IntegrationTest()]` or
   `[Microsoft.DscResourceKit.UnitTest()]`.
-* DcsResource.Container
-  * Now has support for verifying if image, with or without
+- DcsResource.Container
+  - Now has support for verifying if image, with or without
     a tag, exists locally or needs to be pulled from Docker Hub.
-  * Now shows the correct localized message when downloading
+  - Now shows the correct localized message when downloading
     an image.
-  * If 'latest' tag is used on the image name, 'docker pull' will be called to
+  - If 'latest' tag is used on the image name, 'docker pull' will be called to
     make sure the local revision of 'latest' is actually the latest revision on
     Docker Hub. If it isn't, then the latest image will be pulled from Docker Hub.
-* Updated AppVeyor.Tests
-  * Mock for Resolve-CoverageInfo was removed since it was not used.
-  * Moved importing of DscResource.CodeCoverage module to top of AppVeyor.psm1
+- Updated AppVeyor.Tests
+  - Mock for Resolve-CoverageInfo was removed since it was not used.
+  - Moved importing of DscResource.CodeCoverage module to top of AppVeyor.psm1
     for easier mocking.
-* Codecov is once again uploaded for "Harness"-model resource modules
+- Codecov is once again uploaded for "Harness"-model resource modules
   ([issue #229](https://github.com/PowerShell/DscResource.Tests/issues/229)).
-* Changed Example common test
-  * Added support for examples to have mandatory parameters.
-  * Added support for all credential parameters, regardless of parameter name.
-  * Added support to use the same name both for filename and configuration name.
+- Changed Example common test
+  - Added support for examples to have mandatory parameters.
+  - Added support for all credential parameters, regardless of parameter name.
+  - Added support to use the same name both for filename and configuration name.
     Supporting filenames starting with or without a numeric value and a dash,
     e.g '99-MyExample.ps1', or 'MyExample.ps'. Any filename starting with a
     numeric value followed by a dash will be removed. This is to support
     configurations to be able to compile in Azure Automation, but still support
     auto-documentation.
-* Add support for publishing examples configurations to PowerShell Gallery if
+- Add support for publishing examples configurations to PowerShell Gallery if
   opt-in ([issue #234](https://github.com/PowerShell/DscResource.Tests/issues/234)).
-* Added new opt-in common test 'Common Tests - Validate Example Files To Be Published'.
+- Added new opt-in common test 'Common Tests - Validate Example Files To Be Published'.
   This common test verifies that the examples those name ending with '*Config'
   passes testing of script meta data, and that there are no duplicate GUID's in
   the script meta data (within the examples in the repository).
-* Fix bug in `Invoke-AppveyorAfterTestTask` to prevent Wiki generation function
+- Fix bug in `Invoke-AppveyorAfterTestTask` to prevent Wiki generation function
   from getting documentation files from variable `$MainModulePath` defined in
   AppVeyor.yml ([issue #245](https://github.com/PowerShell/DscResource.Tests/issues/245)).
-* Added support for example and integration test configurations compilation using
+- Added support for example and integration test configurations compilation using
   a certificate, so that there are no more need for PSDscAllowPlainTextPassword
   in configurations ([issue #240](https://github.com/PowerShell/DscResource.Tests/issues/240)).
-* Refactored `WikiPages.psm1` to meet guidelines and improve testability.
-* Added unit test coverage for `WikiPages.psm1`.
-* Added support to Wiki generation for Example files that are formatted in the
+- Refactored `WikiPages.psm1` to meet guidelines and improve testability.
+- Added unit test coverage for `WikiPages.psm1`.
+- Added support to Wiki generation for Example files that are formatted in the
   way required by the automatic example publishing code ([issue #247](https://github.com/PowerShell/DscResource.Tests/issues/247)).
-* Added `.gitattributes` to force EOL to be CRLF to make testing more consistent
+- Added `.gitattributes` to force EOL to be CRLF to make testing more consistent
   in unit tests.
-* Make sure the latest PowerShellGet is installed on the AppVeyor Build Worker
+- Make sure the latest PowerShellGet is installed on the AppVeyor Build Worker
   ([issue #252](https://github.com/PowerShell/DscResource.Tests/issues/252)).
-* Update the example pusblishing example to not use `.EXTERNALMODULEDEPENDENCIES`
+- Update the example pusblishing example to not use `.EXTERNALMODULEDEPENDENCIES`
   (only #Requires is needed). `.EXTERNALMODULEDEPENDENCIES` is used for external
   dependencies (outside of PowerShell Gallery).
-* Example publishing can now use a filename without number prefix
+- Example publishing can now use a filename without number prefix
   ([issue #254](https://github.com/PowerShell/DscResource.Tests/issues/254)).
-* Update `New-DscSelfSignedCertificate` to set environment variables even if
+- Update `New-DscSelfSignedCertificate` to set environment variables even if
   certificate already exists.
-* Change `Invoke-AppveyorTestScriptTask` to also create a self-signed certificate
+- Change `Invoke-AppveyorTestScriptTask` to also create a self-signed certificate
   using `New-DscSelfSignedCertificate` so that the certificate environment variables
   are still assigned if the test machine reboots after calling
   `Invoke-AppveyorInstallTask` ([issue #255](https://github.com/PowerShell/DscResource.Tests/issues/255)).
-* Change `New-DscSelfSignedCertificate` to write information about certificate
+- Change `New-DscSelfSignedCertificate` to write information about certificate
   creation or usage so that `Invoke-AppveyorInstallTask` and
   `Invoke-AppveyorTestScriptTask` does not have to ([issue #259](https://github.com/PowerShell/DscResource.Tests/issues/259)).
-* Remove option to use CustomTaskModulePath. It was not used, nor documented. To
+- Remove option to use CustomTaskModulePath. It was not used, nor documented. To
   make the unit tests easier the option was removed
   ([issue #263](https://github.com/PowerShell/DscResource.Tests/issues/263)).
-* Improved the unit tests for the helper function `Invoke-AppveyorTestScriptTask`,
+- Improved the unit tests for the helper function `Invoke-AppveyorTestScriptTask`,
   adding more test coverage, especially for the container part.
-* Moved the import of module DscResource.Container to the top of the module file
+- Moved the import of module DscResource.Container to the top of the module file
   AppVeyor.psm1 to simplify the unit tests.
-* Rearranging the `Import-Module` and the comment-based help, in the module file
+- Rearranging the `Import-Module` and the comment-based help, in the module file
   AppVeyor.psm1, so that the comment-based help is at the top of the file.
-* Fix informational message when publishing examples
+- Fix informational message when publishing examples
   ([issue #261](https://github.com/PowerShell/DscResource.Tests/issues/261)).
-* When cloning this repo and checking out the dev branch, the file
+- When cloning this repo and checking out the dev branch, the file
   DscResource.AnalyzerRules.Tests.ps1 was always unstaged. This was probably
   due to the .gitattributes file that was introduced in a previous PR.
   EOL in DscResource.AnalyzerRules.Tests.ps1 is now fixed.
-* Adding regression tests for
+- Adding regression tests for
   [issue #70](https://github.com/PowerShell/DscResource.Tests/issues/70)).
-* Migrate Pester Test Syntax from v3 -> v4
+- Migrate Pester Test Syntax from v3 -> v4
   ([issue #199](https://github.com/PowerShell/DscResource.Tests/issues/199)).
-* Activate GitHub App Review Me.
-* Removed the default values of the parameter `ExcludeTag` in favor of using
+- Activate GitHub App Review Me.
+- Removed the default values of the parameter `ExcludeTag` in favor of using
   opt-in. Default is that those tests are opt-out, and must be opt-in
   ([issue #274](https://github.com/PowerShell/DscResource.Tests/issues/274)).
-* Excluding tag 'Examples' when calling `Invoke-AppveyorTestScriptTask` since
+- Excluding tag 'Examples' when calling `Invoke-AppveyorTestScriptTask` since
   this repository will never have examples.
+- Added Rule Name to PS Script Analyzer custom rules
+- Added PsScript Analyzer Rule Name to Write-Warning output in meta.tests
 
 ### 0.2.0.0
 
-* Fixed unicode and path bugs in tests
+- Fixed unicode and path bugs in tests
 
 ### 0.1.0.0
 
-* Initial release
+- Initial release

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -2001,6 +2001,45 @@ function Initialize-LocalConfigurationManager
     $null = Remove-Item -LiteralPath $disableConsistencyMofPath -Recurse -Force -Confirm:$false
 }
 
+<#
+    .SYNOPSIS
+        Write a warning message for PsScriptAnalyzer rules that fail
+
+    .PARAMETER PssaRuleOutput
+        Output object from Invoke-ScriptAnalyzer
+
+    .PARAMETER RuleType
+        Name of the rule type that is being processed
+#>
+function Write-PsScriptAnalyzerWarning
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Object[]]
+        $PssaRuleOutput,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $RuleType
+    )
+
+    Write-Warning -Message "$RuleType PSSA rule(s) did not pass."
+    $ruleCollection = $PssaRuleOutput | Group-Object -Property RuleName
+
+    foreach ($ruleNameGroup in $ruleCollection)
+    {
+        Write-Warning -Message "The following PSScriptAnalyzer rule '$($ruleNameGroup.Name)' errors need to be fixed:"
+        foreach ($rule in $ruleNameGroup.Group)
+        {
+            Write-Warning -Message "$($rule.ScriptName) (Line $($rule.Line)): $($rule.Message)"
+        }
+    }
+
+    Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/PSScriptAnalyzer'
+}
+
 Export-ModuleMember -Function @(
     'New-Nuspec',
     'Install-ModuleFromPowerShellGallery',
@@ -2038,4 +2077,5 @@ Export-ModuleMember -Function @(
     'New-DscSelfSignedCertificate',
     'Set-EnvironmentVariable',
     'Initialize-LocalConfigurationManager'
+    'Write-PsScriptAnalyzerWarning'
 )

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -78,6 +78,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
             }
         }
 
@@ -98,6 +99,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeWrongPlace
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
             }
         }
 
@@ -117,6 +119,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
             }
         }
 
@@ -163,6 +166,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
             }
         }
 
@@ -198,6 +202,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeWrongPlace
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
             }
         }
 
@@ -233,6 +238,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
             }
         }
 
@@ -269,6 +275,8 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
                 $record[1].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
+                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
             }
         }
 
@@ -290,6 +298,8 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
                 $record[1].Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
+                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
             }
         }
 
@@ -310,6 +320,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
             }
         }
 
@@ -352,6 +363,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
             }
         }
     }
@@ -380,6 +392,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -400,6 +413,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -420,6 +434,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -463,6 +478,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -481,6 +497,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -499,6 +516,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -517,6 +535,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -675,6 +694,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -697,6 +717,8 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
                 $record[1].Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -718,6 +740,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
+                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
     }
@@ -751,6 +774,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             }
         }
 
@@ -776,6 +800,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -803,6 +828,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
     }
@@ -835,6 +861,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             }
         }
 
@@ -852,6 +879,8 @@ Describe 'Measure-FunctionBlockBraces' {
                 ($record | Measure-Object).Count | Should -BeExactly 2
                 $record[0].Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
                 $record[1].Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
+                $record[0].RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
+                $record[1].RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             }
         }
 
@@ -876,6 +905,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -902,6 +932,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -951,6 +982,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -969,6 +1001,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -989,6 +1022,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
     }
@@ -1013,6 +1047,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1033,6 +1068,8 @@ Describe 'Measure-IfStatement' {
                 ($record | Measure-Object).Count | Should -BeExactly 2
                 $record[0].Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
                 $record[1].Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
+                $record[0].RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
+                $record[1].RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1050,6 +1087,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1069,6 +1107,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1128,6 +1167,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1146,6 +1186,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1167,6 +1208,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1193,6 +1235,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1211,6 +1254,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1231,6 +1275,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1276,6 +1321,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1296,6 +1342,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1318,6 +1365,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
     }
@@ -1345,6 +1393,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1364,6 +1413,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1385,6 +1435,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1432,6 +1483,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1452,6 +1504,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1474,6 +1527,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1502,6 +1556,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1521,6 +1576,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1542,6 +1598,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1589,6 +1646,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1609,6 +1667,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1631,6 +1690,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
     }
@@ -1658,6 +1718,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1677,6 +1738,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1698,6 +1760,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1748,6 +1811,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1771,6 +1835,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1796,6 +1861,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1827,6 +1893,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1847,6 +1914,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1869,6 +1937,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1893,6 +1962,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -1941,6 +2011,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1959,6 +2030,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -1979,6 +2051,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2005,6 +2078,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -2022,6 +2096,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -2041,6 +2116,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2088,6 +2164,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -2110,6 +2187,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -2134,6 +2212,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2164,6 +2243,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -2185,6 +2265,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -2208,6 +2289,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2259,6 +2341,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
             }
         }
 
@@ -2281,6 +2364,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -2305,6 +2389,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2335,6 +2420,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceNotOnSameLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
             }
         }
 
@@ -2356,6 +2442,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
             }
         }
 
@@ -2379,6 +2466,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
             }
         }
 
@@ -2425,6 +2513,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceNotOnSameLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
                 }
             }
 
@@ -2440,6 +2529,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
                 }
             }
 
@@ -2458,6 +2548,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 }
             }
         }
@@ -2478,6 +2569,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceNotOnSameLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
                 }
             }
 
@@ -2496,6 +2588,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
                 }
             }
 
@@ -2516,6 +2609,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 }
             }
         }
@@ -2541,6 +2635,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceNotOnSameLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
                 }
             }
 
@@ -2555,6 +2650,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
                 }
             }
 
@@ -2572,6 +2668,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 }
             }
         }
@@ -2591,6 +2688,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceNotOnSameLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
                 }
             }
 
@@ -2608,6 +2706,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
                 }
             }
 
@@ -2627,6 +2726,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
+                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
                 }
             }
         }

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -61,6 +61,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.ParameterAst'
+            $ruleName = 'Measure-ParameterBlockParameterAttribute'
         }
 
         Context 'When ParameterAttribute is missing' {
@@ -78,7 +79,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -99,7 +100,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeWrongPlace
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -119,7 +120,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Measure-ParameterBlockParameterAttribute -ParameterAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -150,6 +151,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-ParameterBlockParameterAttribute"
         }
 
         Context 'When ParameterAttribute is missing' {
@@ -166,7 +168,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -202,7 +204,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeWrongPlace
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeWrongPlace"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -238,7 +240,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -275,8 +277,8 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
                 $record[1].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
-                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
-                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record[0].RuleName | Should -Be $ruleName
+                $record[1].RuleName | Should -Be $ruleName
             }
         }
 
@@ -298,8 +300,8 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
                 $record[1].Message | Should -Be $localizedData.ParameterBlockParameterAttributeLowerCase
-                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
-                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeLowerCase"
+                $record[0].RuleName | Should -Be $ruleName
+                $record[1].RuleName | Should -Be $ruleName
             }
         }
 
@@ -320,7 +322,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -363,7 +365,7 @@ Describe 'Measure-ParameterBlockParameterAttribute' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterAttributeMissing
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterAttributeMissing"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -373,6 +375,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.NamedAttributeArgumentAst'
+            $ruleName = 'Measure-ParameterBlockMandatoryNamedArgument'
         }
 
         Context 'When Mandatory is included and set to $false' {
@@ -392,7 +395,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -413,7 +416,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -434,7 +437,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Measure-ParameterBlockMandatoryNamedArgument -NamedAttributeArgumentAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -461,6 +464,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-ParameterBlockMandatoryNamedArgument"
         }
 
         Context 'When Mandatory is included and set to $false' {
@@ -478,7 +482,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -497,7 +501,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -516,7 +520,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -535,7 +539,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -694,7 +698,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -717,8 +721,6 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 ($record | Measure-Object).Count | Should -Be 2
                 $record[0].Message | Should -Be $localizedData.ParameterBlockParameterMandatoryAttributeWrongFormat
                 $record[1].Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-                $record[0].RuleName | Should -Be "$($script:moduleName)\ParameterBlockParameterMandatoryAttributeWrongFormat"
-                $record[1].RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
             }
         }
 
@@ -740,7 +742,7 @@ Describe 'Measure-ParameterBlockMandatoryNamedArgument' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat
-                $record.RuleName | Should -Be "$($script:moduleName)\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -750,6 +752,7 @@ Describe 'Measure-FunctionBlockBraces' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.FunctionDefinitionAst'
+            $ruleName = 'Measure-FunctionBlockBraces'
         }
 
         Context 'When a functions opening brace is on the same line as the function keyword' {
@@ -774,7 +777,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -800,7 +803,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -828,7 +831,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Measure-FunctionBlockBraces -FunctionDefinitionAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -838,6 +841,7 @@ Describe 'Measure-FunctionBlockBraces' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-FunctionBlockBraces"
         }
 
         Context 'When a functions opening brace is on the same line as the function keyword' {
@@ -861,7 +865,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -879,8 +883,6 @@ Describe 'Measure-FunctionBlockBraces' {
                 ($record | Measure-Object).Count | Should -BeExactly 2
                 $record[0].Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
                 $record[1].Message | Should -Be $localizedData.FunctionOpeningBraceNotOnSameLine
-                $record[0].RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
-                $record[1].RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceNotOnSameLine"
             }
         }
 
@@ -905,7 +907,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -932,7 +934,7 @@ Describe 'Measure-FunctionBlockBraces' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\FunctionOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -966,6 +968,7 @@ Describe 'Measure-IfStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.IfStatementAst'
+            $ruleName = 'Measure-IfStatement'
         }
 
         Context 'When if-statement has an opening brace on the same line' {
@@ -982,7 +985,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1001,7 +1004,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1022,7 +1025,7 @@ Describe 'Measure-IfStatement' {
                 $record = Measure-IfStatement -IfStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -1032,6 +1035,7 @@ Describe 'Measure-IfStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-IfStatement"
         }
 
         Context 'When if-statement has an opening brace on the same line' {
@@ -1047,7 +1051,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1068,8 +1072,6 @@ Describe 'Measure-IfStatement' {
                 ($record | Measure-Object).Count | Should -BeExactly 2
                 $record[0].Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
                 $record[1].Message | Should -Be $localizedData.IfStatementOpeningBraceNotOnSameLine
-                $record[0].RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
-                $record[1].RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceNotOnSameLine"
             }
         }
 
@@ -1087,7 +1089,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1107,7 +1109,7 @@ Describe 'Measure-IfStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\IfStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1150,6 +1152,7 @@ Describe 'Measure-ForEachStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.ForEachStatementAst'
+            $ruleName = 'Measure-ForEachStatement'
         }
 
         Context 'When foreach-statement has an opening brace on the same line' {
@@ -1167,7 +1170,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1186,7 +1189,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1208,7 +1211,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Measure-ForEachStatement -ForEachStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1219,6 +1222,7 @@ Describe 'Measure-ForEachStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-ForEachStatement"
         }
 
         Context 'When foreach-statement has an opening brace on the same line' {
@@ -1235,7 +1239,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1254,7 +1258,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1275,7 +1279,7 @@ Describe 'Measure-ForEachStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForEachStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1302,6 +1306,7 @@ Describe 'Measure-DoUntilStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.DoUntilStatementAst'
+            $ruleName = 'Measure-DoUntilStatement'
         }
 
         Context 'When DoUntil-statement has an opening brace on the same line' {
@@ -1321,7 +1326,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1342,7 +1347,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1365,7 +1370,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Measure-DoUntilStatement -DoUntilStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -1375,6 +1380,7 @@ Describe 'Measure-DoUntilStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-DoUntilStatement"
         }
 
         Context 'When DoUntil-statement has an opening brace on the same line' {
@@ -1393,7 +1399,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1413,7 +1419,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1435,7 +1441,7 @@ Describe 'Measure-DoUntilStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoUntilStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1464,6 +1470,7 @@ Describe 'Measure-DoWhileStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.DoWhileStatementAst'
+            $ruleName = 'Measure-DoWhileStatement'
         }
 
         Context 'When DoWhile-statement has an opening brace on the same line' {
@@ -1483,7 +1490,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1504,7 +1511,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1527,7 +1534,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Measure-DoWhileStatement -DoWhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1538,6 +1545,7 @@ Describe 'Measure-DoWhileStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-DoWhileStatement"
         }
 
         Context 'When DoWhile-statement has an opening brace on the same line' {
@@ -1556,7 +1564,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1576,7 +1584,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1598,7 +1606,7 @@ Describe 'Measure-DoWhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\DoWhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1627,6 +1635,7 @@ Describe 'Measure-WhileStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.WhileStatementAst'
+            $ruleName = 'Measure-WhileStatement'
         }
 
         Context 'When While-statement has an opening brace on the same line' {
@@ -1646,7 +1655,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1667,7 +1676,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1690,7 +1699,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Measure-WhileStatement -WhileStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
     }
@@ -1700,6 +1709,7 @@ Describe 'Measure-WhileStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-WhileStatement"
         }
 
         Context 'When While-statement has an opening brace on the same line' {
@@ -1718,7 +1728,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1738,7 +1748,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1760,7 +1770,7 @@ Describe 'Measure-WhileStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\WhileStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1789,6 +1799,7 @@ Describe 'Measure-SwitchStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.SwitchStatementAst'
+            $ruleName = 'Measure-SwitchStatement'
         }
 
         Context 'When Switch-statement has an opening brace on the same line' {
@@ -1811,7 +1822,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1835,7 +1846,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1861,7 +1872,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Measure-SwitchStatement -SwitchStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1872,6 +1883,7 @@ Describe 'Measure-SwitchStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-SwitchStatement"
         }
 
         Context 'When Switch-statement has an opening brace on the same line' {
@@ -1893,7 +1905,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1914,7 +1926,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1937,7 +1949,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1962,7 +1974,7 @@ Describe 'Measure-SwitchStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\SwitchStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -1994,6 +2006,7 @@ Describe 'Measure-ForStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.ForStatementAst'
+            $ruleName = 'Measure-ForStatement'
         }
 
         Context 'When For-statement has an opening brace on the same line' {
@@ -2011,7 +2024,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2030,7 +2043,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2051,7 +2064,7 @@ Describe 'Measure-ForStatement' {
                 $record = Measure-ForStatement -ForStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2062,6 +2075,7 @@ Describe 'Measure-ForStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-ForStatement"
         }
 
         Context 'When For-statement has an opening brace on the same line' {
@@ -2078,7 +2092,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2096,7 +2110,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2116,7 +2130,7 @@ Describe 'Measure-ForStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\ForStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2143,6 +2157,7 @@ Describe 'Measure-TryStatement' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.TryStatementAst'
+            $ruleName = 'Measure-TryStatement'
         }
 
         Context 'When Try-statement has an opening brace on the same line' {
@@ -2164,7 +2179,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2187,7 +2202,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2212,7 +2227,7 @@ Describe 'Measure-TryStatement' {
                 $record = Measure-TryStatement -TryStatementAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2223,6 +2238,7 @@ Describe 'Measure-TryStatement' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-TryStatement"
         }
 
         Context 'When Try-statement has an opening brace on the same line' {
@@ -2243,7 +2259,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2265,7 +2281,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2289,7 +2305,7 @@ Describe 'Measure-TryStatement' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\TryStatementOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2320,6 +2336,7 @@ Describe 'Measure-CatchClause' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.CatchClauseAst'
+            $ruleName = 'Measure-CatchClause'
         }
 
         Context 'When Catch-clause has an opening brace on the same line' {
@@ -2341,7 +2358,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2364,7 +2381,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2389,7 +2406,7 @@ Describe 'Measure-CatchClause' {
                 $record = Measure-CatchClause -CatchClauseAst $mockAst[0]
                 ($record | Measure-Object).Count | Should -Be 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2400,6 +2417,7 @@ Describe 'Measure-CatchClause' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-CatchClause"
         }
 
         Context 'When Catch-clause has an opening brace on the same line' {
@@ -2420,7 +2438,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceNotOnSameLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceNotOnSameLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2442,7 +2460,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2466,7 +2484,7 @@ Describe 'Measure-CatchClause' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -BeExactly 1
                 $record.Message | Should -Be $localizedData.CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                $record.RuleName | Should -Be "$($script:moduleName)\CatchClauseOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                $record.RuleName | Should -Be $ruleName
             }
         }
 
@@ -2497,6 +2515,7 @@ Describe 'Measure-TypeDefinition' {
     Context 'When calling the function directly' {
         BeforeAll {
             $astType = 'System.Management.Automation.Language.TypeDefinitionAst'
+            $ruleName = 'Measure-TypeDefinition'
         }
 
         Context 'Enum' {
@@ -2513,7 +2532,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceNotOnSameLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2529,7 +2548,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2548,7 +2567,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
         }
@@ -2569,7 +2588,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceNotOnSameLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2588,7 +2607,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2609,7 +2628,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Measure-TypeDefinition -TypeDefinitionAst $mockAst[0]
                     ($record | Measure-Object).Count | Should -Be 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
         }
@@ -2620,6 +2639,7 @@ Describe 'Measure-TypeDefinition' {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
+            $ruleName = "$($script:ModuleName)\Measure-TypeDefinition"
         }
 
         Context 'Enum' {
@@ -2635,7 +2655,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceNotOnSameLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceNotOnSameLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2650,7 +2670,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2668,7 +2688,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
         }
@@ -2688,7 +2708,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceNotOnSameLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceNotOnSameLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2706,7 +2726,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
 
@@ -2726,7 +2746,7 @@ Describe 'Measure-TypeDefinition' {
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                     ($record | Measure-Object).Count | Should -BeExactly 1
                     $record.Message | Should -Be $localizedData.ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine
-                    $record.RuleName | Should -Be "$($script:moduleName)\ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine"
+                    $record.RuleName | Should -Be $ruleName
                 }
             }
         }

--- a/Tests/Unit/TestHelper.Tests.ps1
+++ b/Tests/Unit/TestHelper.Tests.ps1
@@ -1015,12 +1015,12 @@ InModuleScope $script:ModuleName {
 
                 Assert-MockCalled -CommandName 'Set-PSModulePath' -ParameterFilter {
                     $Path -eq $testEnvironmentParameter.OldPSModulePath `
-                    -and $PSBoundParameters.ContainsKey('Machine') -eq $false
+                        -and $PSBoundParameters.ContainsKey('Machine') -eq $false
                 } -Exactly -Times 1 -Scope It
 
                 Assert-MockCalled -CommandName 'Set-PSModulePath' -ParameterFilter {
                     $Path -eq $testEnvironmentParameter.OldPSModulePath `
-                    -and $PSBoundParameters.ContainsKey('Machine') -eq $true
+                        -and $PSBoundParameters.ContainsKey('Machine') -eq $true
                 } -Exactly -Times 1 -Scope It
             }
         }
@@ -1494,12 +1494,12 @@ InModuleScope $script:ModuleName {
 
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscPublicCertificatePath' `
-                    -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
+                        -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
                 } -Exactly -Times 1
 
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscCertificateThumbprint' `
-                    -and $Value -eq $mockCertificateThumbprint
+                        -and $Value -eq $mockCertificateThumbprint
                 } -Exactly -Times 1
             }
         }
@@ -1540,12 +1540,12 @@ InModuleScope $script:ModuleName {
                 Assert-MockCalled -CommandName New-SelfSignedCertificate -Exactly -Times 1
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscPublicCertificatePath' `
-                    -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
+                        -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
                 } -Exactly -Times 1
 
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscCertificateThumbprint' `
-                    -and $Value -eq $mockCertificateThumbprint
+                        -and $Value -eq $mockCertificateThumbprint
                 } -Exactly -Times 1
             }
         }
@@ -1582,12 +1582,12 @@ InModuleScope $script:ModuleName {
                 Assert-MockCalled -CommandName New-SelfSignedCertificateEx -Exactly -Times 0
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscPublicCertificatePath' `
-                    -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
+                        -and $Value -eq (Join-Path -Path $env:temp -ChildPath 'DscPublicKey.cer')
                 } -Exactly -Times 1
 
                 Assert-MockCalled -CommandName Set-EnvironmentVariable -ParameterFilter {
                     $Name -eq 'DscCertificateThumbprint' `
-                    -and $Value -eq $mockCertificateThumbprint
+                        -and $Value -eq $mockCertificateThumbprint
                 } -Exactly -Times 1
                 Assert-MockCalled -CommandName Install-Module -Exactly -Times 0
                 Assert-MockCalled -CommandName Import-Module -Exactly -Times 0
@@ -1670,4 +1670,33 @@ InModuleScope $script:ModuleName {
         }
     }
 
+    Describe 'TestHelper\Write-PsScriptAnalyzerWarning' {
+        Context 'When writing a PsScriptAnalyzer warning' {
+            BeforeAll {
+                $testPssaRuleOutput = [PSCustomObject]@{
+                    Line   = '51'
+                    Message  = 'Test Message'
+                    RuleName = 'TestRule'
+                    ScriptName = 'Pester.ps1'
+                }
+                $testRuleType = 'Test'
+                
+                Mock -CommandName 'Write-Warning'
+            }
+
+            It 'Should call the correct Cmdlets and not throw' {
+                { Write-PsScriptAnalyzerWarning -PssaRuleOutput $testPssaRuleOutput -RuleType $testRuleType } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName 'Write-Warning' -ParameterFilter {
+                    $message -eq "The following PSScriptAnalyzer rule '$($testPssaRuleOutput.RuleName)' errors need to be fixed:"
+                } -Exactly -Times 1
+                Assert-MockCalled -CommandName 'Write-Warning' -ParameterFilter {
+                    $message -eq "$($testPssaRuleOutput.ScriptName) (Line $($testPssaRuleOutput.Line)): $($testPssaRuleOutput.Message)"
+                } -Exactly -Times 1
+                Assert-MockCalled -CommandName 'Write-Warning' -ParameterFilter {
+                    $message -eq "$testRuleType PSSA rule(s) did not pass."
+                } -Exactly -Times 1
+            }
+        }
+    }
 }


### PR DESCRIPTION
This addresses #265, where custom PSSA rules were not returning a value for the RuleName property.  This previously prevented custom rules from being suppressed using SuppressMessageAttribute.  

With this change, each rule uses the same property name that was being use for $localizedData and uses that for the RuleName.  This makes it easy for testing purposes and consistency throughout the module.  The rule name is also prefixed with the module name, so rule names look like this: 'DscResource.AnalyzerRules\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat'.

It is a bit verbose now, but is specific and now supports suppressing specific rules within the custom PSSA module like this:
`[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('DscResource.AnalyzerRules\ParameterBlockNonMandatoryParameterMandatoryAttributeWrongFormat','')]
`

Fixes #265 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/275)
<!-- Reviewable:end -->
