### PR TITLE
Adding opt-in common test for spellchecking markdown files

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -2,5 +2,6 @@
     "Common Tests - Validate Module Files",
     "Common Tests - Validate Markdown Files",
     "Common Tests - Validate Example Files",
-    "Common Tests - Validate Script Files"
+    "Common Tests - Validate Script Files",
+    "Common Tests - Spellcheck Markdown Files"
 ]

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -12,7 +12,9 @@
         "Codecov",
         "HQRM",
         "GUIDs",
-        "unstaged"
+        "unstaged",
+        "PSSA",
+        "Dism"
     ],
     "ignoreRegExpList": [
         "AppVeyor",
@@ -38,6 +40,13 @@
         "2016-Datacenter",
         "2016-Datacenter-Server-Core",
         "HKLM:\\\\",
-        "\\.gitattributes"
+        "\\.gitattributes",
+        "#psscriptanalyzer-rules",
+        "#metafixers-module",
+        "#testhelper-module",
+        "#example-usage-of-dscresourcetests-in-appveyoryml",
+        "#codecoverage-reporting-with-codecovio",
+        "#enable-reporting-to-codecovio",
+        "#configure-codecovio"
     ]
 }

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -14,7 +14,9 @@
         "GUIDs",
         "unstaged",
         "PSSA",
-        "Dism"
+        "Dism",
+        "vors",
+        "subfolders"
     ],
     "ignoreRegExpList": [
         "AppVeyor",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -9,7 +9,7 @@
     ],
     "words": [
         "markdownlint",
-        "codecov",
+        "Codecov",
         "HQRM",
         "GUIDs",
         "unstaged"

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,0 +1,43 @@
+{
+    "ignorePaths": [
+        ".git/*",
+        ".vscode/*"
+    ],
+    "language": "en",
+    "dictionaries": [
+        "powershell"
+    ],
+    "words": [
+        "markdownlint",
+        "codecov",
+        "HQRM",
+        "GUIDs",
+        "unstaged"
+    ],
+    "ignoreRegExpList": [
+        "AppVeyor",
+        "opencode@microsoft.com",
+        "\\.PRIVATEDATA",
+        "\\.COMPANYNAME",
+        "\\.LICENSEURI",
+        "\\.PROJECTURI",
+        "\\.ICONURI",
+        "\\.EXTERNALMODULEDEPENDENCIES",
+        "\\.REQUIREDSCRIPTS",
+        "\\.EXTERNALSCRIPTDEPENDENCIES",
+        "\\.RELEASENOTES",
+        "gulpfile.js",
+        "MSFT_",
+        "microsoft/windowsservercore",
+        "unittest_Transcript.txt",
+        "unittest_TestResults.xml",
+        "unittest_TestResults.json",
+        "unittest_DockerLog.txt",
+        "core\\.autocrlf=input",
+        "core\\.autocrlf true",
+        "2016-Datacenter",
+        "2016-Datacenter-Server-Core",
+        "HKLM:\\\\",
+        "\\.gitattributes"
+    ]
+}

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -1124,6 +1124,17 @@ Describe 'Common Tests - Spellcheck Files' -Tag 'Spellcheck' {
         # If the It-block did not pass the test, output the spelling errors.
         if ($itBlockError.Count -ne 0)
         {
+            $message = @"
+There were spelling errors. If these are false negatives, then please add the
+word or phrase to the settings file '/.vscode/cSpell.json' in the repository.
+See this section for more information.
+https://github.com/PowerShell/DscResource.Tests/#common-tests-spellcheck-markdownfiles
+
+"@
+
+            Write-Host -BackgroundColor Yellow -ForegroundColor Black -Object $message
+            Write-Host -ForegroundColor White -Object ''
+
             $misspelledErrors = Get-Content -Path $errorFileName
 
             foreach ($misspelledError in $misspelledErrors)

--- a/Meta.Tests.ps1
+++ b/Meta.Tests.ps1
@@ -1082,6 +1082,7 @@ Describe 'Common Tests - Spellcheck Files' -Tag 'Spellcheck' {
 
         It 'Should not have spelling errors in any markdown files' -Skip:(!$optIn) {
             $spellcheckSettingsFilePath = Join-Path -Path $repoRootPath -ChildPath '.vscode\cSpell.json'
+
             if (Test-Path -Path $spellcheckSettingsFilePath)
             {
                 Write-Info -Message ('Using spellcheck settings file ''{0}''.' -f $spellcheckSettingsFilePath)
@@ -1147,7 +1148,7 @@ https://github.com/PowerShell/DscResource.Tests/#common-tests-spellcheck-markdow
         # Make sure we always remove the file if it exist.
         if (Test-Path $errorFileName)
         {
-            Remove-Item -Path $errorFileName -Force
+            Remove-Item -Path $errorFileName -Force | Out-Null
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ the tests will fail.
 If the spell checker ([cSpell](https://www.npmjs.com/package/cspell)) does not
 recognize the word, but the word is correct or a specific phrase is not recognized
 but should be allowed, then it is possible to add these to a dictionary or tell it to
-ignore the word of phrases. This is done by adding a `\.vscode\cSpell.json` in
+ignore the word or phrases. This is done by adding a `\.vscode\cSpell.json` in
 the repository.
 
 The following JSON is the simplest form of the file `\.vscode\cSpell.json` (see

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The following opt-in flags are available:
   DSC resource module.
 - **Common Tests - Validate Markdown Links**: fails tests if a link in
   a markdown file is broken.
-* **Common Tests - Spellcheck Markdown Files**: fail test if there are any
+- **Common Tests - Spellcheck Markdown Files**: fail test if there are any
   spelling errors in the markdown files. There is the possibility to add
   or override words in the `\.vscode\cSpell.json` file.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This branch is used by DSC Resource Kit modules for running common tests.
 - [Encrypt Credentials in Integration Tests](#encrypt-credentials-in-integration-tests)
 - [CodeCoverage reporting with CodeCov.io](#codecoverage-reporting-with-codecovio)
   - [Ensure Code Coverage is enabled](#ensure-code-coverage-is-enabled)
-  - [Enable reporting to CodeCove.io](#enable-reporting-to-codecoveio)
+  - [Enable reporting to CodeCov.io](#enable-reporting-to-codecovio)
   - [Configure CodeCov.io](#configure-codecovio)
   - [Add the badge to the Readme](#add-the-badge-to-the-readme)
 - [Documentation Helper Module](#documentation-helper-module)
@@ -475,7 +475,7 @@ Defaults to the relative paths 'DSCResources', 'DSCClassResources', and 'Modules
 1. Make sure you are properly generating pester code coverage in the repository
    harness code.
 
-### Enable reporting to CodeCove.io
+### Enable reporting to CodeCov.io
 
 1. On the call to `Invoke-AppveyorTestScriptTask`, specify
    `-CodeCovIo`.  This will enable reporting to [codecov.io](http://codecov.io)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The key `ignoreRegExpList` is used to ignore phrases or combinations of words,
 such as `AppVeyor`, which will be detected as two different words since it consists
 of two words starting with upper-case letters.
 To configure [cSpell](https://www.npmjs.com/package/cspell)
-to ignore the work combination `AppVeyor`, then we can add a regular expression,
+to ignore the word combination `AppVeyor`, then we can add a regular expression,
 in this case `AppVeyor`. This will cause [cSpell](https://www.npmjs.com/package/cspell)
 to ignore part of the text that matches the regular expression.
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ The following opt-in flags are available:
   DSC resource module.
 - **Common Tests - Validate Markdown Links**: fails tests if a link in
   a markdown file is broken.
+* **Common Tests - Spellcheck Markdown Files**: fail test if there are any
+  spelling errors in the markdown files. There is the possibility to add
+  or override words in the `.vscode\cSpell.json` file.
 
 #### Common Tests - Validate Markdown Links
 
@@ -1019,6 +1022,9 @@ Contributors that add or change an example to be published must make sure that
   ([issue #188](https://github.com/PowerShell/DscResource.Tests/issues/188)).
 - Add new opt-in common test for markdown link linting
   ([issue #211](https://github.com/PowerShell/DscResource.Tests/issues/211)).
+* Adding opt-in common test for spellchecking markdown files. Opt-in by
+  adding "Common Tests - Spellcheck Markdown Files" in the file
+  .MetaTestOptIn.json ([issue #211](https://github.com/PowerShell/DscResource.Tests/issues/211)).
 
 ### 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -120,21 +120,19 @@ will pass the linter.
 
 #### Common Tests - Spellcheck Markdown Files
 
-When opt-in for this test, if there are any spelling errors in markdown files,
+When opt-in to this test, if there are any spelling errors in markdown files,
 the tests will fail.
 
 >**Note:** The spell checker is case-insensitive, so the words 'AppVeyor' and
->'appveyor' is equal and both allowed.
+>'appveyor' are equal and both are allowed.
 
 If the spell checker ([cSpell](https://www.npmjs.com/package/cspell)) does not
-recognize the word, but the word are correct, or maybe there are a specific phrase
-that should always be allowed. Then it possible to add those to a dictionary, or
-tell it to ignore words or phrases.
+recognize the word, but the word is correct or a specific phrase is not recognized
+but should be allowed, then it is possible to add these to a dictionary or tell it to
+ignore the word of phrases. This is done by adding a `\.vscode\cSpell.json` in
+the repository.
 
-By adding a file `\.vscode\cSpell.json` in the repository, the spell checker
-will follow the settings in this file.
-
-The simplest form of the file `\.vscode\cSpell.json` is this (see
+The following JSON is the simplest form of the file `\.vscode\cSpell.json` (see
 [cSpell](https://www.npmjs.com/package/cspell) for more settings).
 
 >This settings file will also work together with the Visual Studio Code extension
@@ -171,12 +169,13 @@ The simplest form of the file `\.vscode\cSpell.json` is this (see
 
 The key `words` should have the words that are normally used when writing text.
 
-The key `ignoreRegExpList` is better to use to ignore phrases or combination of
-words, like 'AppVeyor', it will detect that word as two different words, since
-it consist of two words with upper-case letter.
-So for it to ignore 'AppVeyor', as we know it's correct, we can add a regular
-expression to `ignoreRegExpList`, in this case `AppVeyor`. That will ignore part
-of the text that matches the regular expression.
+The key `ignoreRegExpList` is used to ignore phrases or combinations of words,
+such as `AppVeyor`, which will be detected as two different words since it consists
+of two words starting with upper-case letters.
+To configure [cSpell](https://www.npmjs.com/package/cspell)
+to ignore the work combination `AppVeyor`, then we can add a regular expression,
+in this case `AppVeyor`. This will cause [cSpell](https://www.npmjs.com/package/cspell)
+to ignore part of the text that matches the regular expression.
 
 ### Markdown Testing
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ fails, you should be able to run `ConvertTo-UTF8` fixer from [MetaFixers.psm1](M
 
 The test helper module (TestHelper.psm1) contains the following functions:
 
-- **New-Nuspec**: Creates a new nuspec file for nuget package.
+- **New-Nuspec**: Creates a new nuspec file for NuGet package.
 - **Install-ResourceDesigner**: Will attempt to download the
-  xDSCResourceDesignerModule using Nuget package and return the module.
+  xDSCResourceDesignerModule using NuGet package and return the module.
 - **Initialize-TestEnvironment**: Initializes an environment for running unit or
   integration tests on a DSC resource.
 - **Restore-TestEnvironment**: Restores the environment after running unit or
@@ -743,7 +743,7 @@ Contributors that add or change an example to be published must make sure that
   - Added more test helper functions
 - Cleaned MetaFixers and TestRunner
 - Updated common test output format
-- Added ```Install-NugetExe``` to TestHelper.psm1
+- Added ```Install-NuGetExe``` to TestHelper.psm1
 - Fixed up Readme.md to remove markdown violations and resolve duplicate information
 - Added ```AppVeyor.psm1``` module
 - Added ```DscResource.DocumentationHelper``` modules
@@ -795,8 +795,9 @@ Contributors that add or change an example to be published must make sure that
 - Added new common test so that script files (.ps1) are checked for Byte Order
   Mark (BOM) ([issue #160](https://github.com/PowerShell/DscResource.Tests/issues/160)).
   This test is opt-in using .MetaTestOptIn.json.
-- Added minimum viable product for applying custom PSSA rules to check adherence to
-  DSC Resource Kit style guidelines ([issue #86](https://github.com/PowerShell/DscResource.Tests/issues/86)).
+- Added minimum viable product for applying custom PS Script Analyzer rules to
+  check adherence to DSC Resource Kit style guidelines
+  ([issue #86](https://github.com/PowerShell/DscResource.Tests/issues/86)).
   The current rules checks the [Parameter()] attribute format is correct in all parameter blocks.
   - Fixed Byte Order Mark (BOM) in files; DscResource.AnalyzerRules.psd1,
   DscResource.AnalyzerRules.psm1 and en-US/DscResource.AnalyzerRules.psd1
@@ -840,7 +841,7 @@ Contributors that add or change an example to be published must make sure that
 - When common tests are running on another repository than DscResource.Tests the
   DscResource.Tests unit and integration tests are removed from the list of tests
   to run ([issue #189](https://github.com/PowerShell/DscResource.Tests/issues/189)).
-- Fix ModuleVersion number value inserted into manifest in Nuget package produced
+- Fix ModuleVersion number value inserted into manifest in NuGet package produced
   in Invoke-AppveyorAfterTestTask ([issue #193](https://github.com/PowerShell/DscResource.Tests/issues/193)).
 - Fix TestRunner.Tests.ps1 to make compatible with Pester 4.0.7 ([issue #196](https://github.com/PowerShell/DscResource.Tests/issues/196)).
 - Improved WikiPages.psm1 to include the EmbeddedInstance to the datatype in the
@@ -874,13 +875,13 @@ Contributors that add or change an example to be published must make sure that
 - Added module DscResource.Container which contain logic to handle the container
   testing when unit tests are run in a Docker Windows container.
 - Added Get-OptInStatus function to enable retrieving of an opt-in status
-  by name. This is required for implementation of PSSA opt-in rules where
-  the describe block contains multiple opt-ins in a single block.
+  by name. This is required for implementation of PS Script Analyzer opt-in rules
+  where the describe block contains multiple opt-ins in a single block.
 - Added new opt-in flags to allow enforcement of script analyzer rules ([issue #161](https://github.com/PowerShell/DscResource.Tests/issues/161))
 - Updated year in DscResources.Tests.psd1 manifest to 2018.
 - Fixed bug where common test would throw an error if there were no
   .MetaTestOptIn.json file or it was empty (no opt-ins).
-- Added more tests for custom Script Analazyer rules to increased code coverage.
+- Added more tests for custom PS Script Analyzer rules to increased code coverage.
   These new tests call the Measure-functions directly.
 - Changed so that DscResource.Tests repository can analyze code coverage for the
   helper modules ([issue #208](https://github.com/PowerShell/DscResource.Tests/issues/208)).
@@ -891,7 +892,7 @@ Contributors that add or change an example to be published must make sure that
 - Changed Get-PSModulePathItem to trim end back slash ([issue #217](https://github.com/PowerShell/DscResource.Tests/issues/217))
 - Updated to support running unit tests on PowerShell Core:
   - Updated helper function Test-FileHasByteOrderMark to use `AsByteStream`.
-  - Install-PackageProvider will only run if `Find-PackageProvider -Name 'Nuget'`
+  - Install-PackageProvider will only run if `Find-PackageProvider -Name 'NuGet'`
     returns a package. Currently it is not found on the AppVeyor build worker for
     PowerShell Core.
   - Adding tests to AppVeyor test pane is done by using the RestAPI because the
@@ -949,7 +950,7 @@ Contributors that add or change an example to be published must make sure that
   opt-in ([issue #234](https://github.com/PowerShell/DscResource.Tests/issues/234)).
 - Added new opt-in common test 'Common Tests - Validate Example Files To Be Published'.
   This common test verifies that the examples those name ending with '*Config'
-  passes testing of script meta data, and that there are no duplicate GUID's in
+  passes testing of script meta data, and that there are no duplicate GUIDs in
   the script meta data (within the examples in the repository).
 - Fix bug in `Invoke-AppveyorAfterTestTask` to prevent Wiki generation function
   from getting documentation files from variable `$MainModulePath` defined in
@@ -965,7 +966,7 @@ Contributors that add or change an example to be published must make sure that
   in unit tests.
 - Make sure the latest PowerShellGet is installed on the AppVeyor Build Worker
   ([issue #252](https://github.com/PowerShell/DscResource.Tests/issues/252)).
-- Update the example pusblishing example to not use `.EXTERNALMODULEDEPENDENCIES`
+- Update the example publishing example to not use `.EXTERNALMODULEDEPENDENCIES`
   (only #Requires is needed). `.EXTERNALMODULEDEPENDENCIES` is used for external
   dependencies (outside of PowerShell Gallery).
 - Example publishing can now use a filename without number prefix
@@ -1004,8 +1005,8 @@ Contributors that add or change an example to be published must make sure that
   ([issue #274](https://github.com/PowerShell/DscResource.Tests/issues/274)).
 - Excluding tag 'Examples' when calling `Invoke-AppveyorTestScriptTask` since
   this repository will never have examples.
-- Added Rule Name to PS Script Analyzer custom rules
-- Added PsScript Analyzer Rule Name to Write-Warning output in meta.tests
+- Added Rule Name to PS Script Analyzer custom rules.
+- Added PS Script Analyzer Rule Name to Write-Warning output in meta.tests.
 - Removed sections 'Goals' and 'Git and Unicode' as they have become redundant.
 - Add a new parameter `-CodeCoveragePath` in the function
   `Invoke-AppveyorTestScriptTask` to be able to add one or more relative
@@ -1022,9 +1023,11 @@ Contributors that add or change an example to be published must make sure that
   ([issue #188](https://github.com/PowerShell/DscResource.Tests/issues/188)).
 - Add new opt-in common test for markdown link linting
   ([issue #211](https://github.com/PowerShell/DscResource.Tests/issues/211)).
-* Adding opt-in common test for spellchecking markdown files. Opt-in by
+- Adding opt-in common test for spellchecking markdown files. Opt-in by
   adding "Common Tests - Spellcheck Markdown Files" in the file
   .MetaTestOptIn.json ([issue #211](https://github.com/PowerShell/DscResource.Tests/issues/211)).
+- Opt-in for the test "Common Tests - Spellcheck Markdown Files", and added the
+  settings file `.vscode\cSpell.json`.
 
 ### 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,13 @@ The simplest form of the file `\.vscode\cSpell.json` is this (see
 
 >This settings file will also work together with the Visual Studio Code extension
 >[Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).
->By using the extension the spelling errors can be caught in real-time.
+>By using this extension the spelling errors can be caught in real-time.
+>When a cSpell.json exists in the .vscode folder, the individual setting in the
+>cSpell.json file will override the corresponding setting in the
+>Visual Studio Code *User settings* or *Workspace settings* file. This differs
+>from adding a *Code Spell Checker* setting to the Visual Studio Code
+>*Workspace settings* file, as the *Workspace settings* file will override all
+>the settings in the *User settings*.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -298,7 +298,61 @@ The following opt-in flags are available:
   a markdown file is broken.
 * **Common Tests - Spellcheck Markdown Files**: fail test if there are any
   spelling errors in the markdown files. There is the possibility to add
-  or override words in the `.vscode\cSpell.json` file.
+  or override words in the `\.vscode\cSpell.json` file.
+
+#### Common Tests - Spellcheck Markdown Files
+
+When opt-in for this test, if there are any spelling errors in markdown files,
+the tests will fail.
+
+>**Note:** The spell checker is case-insensitive, so the words 'AppVeyor' and
+>'appveyor' is equal and both allowed.
+
+If the spell checker ([cSpell](https://www.npmjs.com/package/cspell)) does not
+recognize the word, but the word are correct, or maybe there are a specific phrase
+that should always be allowed. Then it possible to add those to a dictionary, or
+tell it to ignore words or phrases.
+
+By adding a file `\.vscode\cSpell.json` in the repository, the spell checker
+will follow the settings in this file.
+
+The simplest form of the file `\.vscode\cSpell.json` is this (see
+[cSpell](https://www.npmjs.com/package/cspell) for more settings).
+
+>This settings file will also work together with the Visual Studio Code extension
+>[Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).
+>By using the extension the spelling errors can be caught in real-time.
+
+```json
+{
+    "ignorePaths": [
+        ".git/*",
+        ".vscode/*"
+    ],
+    "language": "en",
+    "dictionaries": [
+        "powershell"
+    ],
+    "words": [
+        "markdownlint",
+        "Codecov"
+    ],
+    "ignoreRegExpList": [
+        "AppVeyor",
+        "opencode@microsoft.com",
+        "\\.gitattributes"
+    ]
+}
+```
+
+The key `words` should have the words that are normally used when writing text.
+
+The key `ignoreRegExpList` is better to use to ignore phrases or combination of
+words, like 'AppVeyor', it will detect that word as two different words, since
+it consist of two words with upper-case letter.
+So for it to ignore 'AppVeyor', as we know it's correct, we can add a regular
+expression to `ignoreRegExpList`, in this case `AppVeyor`. That will ignore part
+of the text that matches the regular expression.
 
 #### Common Tests - Validate Markdown Links
 


### PR DESCRIPTION
- Adding opt-in common test for spellchecking markdown files. Opt-in by
  adding "Common Tests - Spellcheck Markdown Files" in the file
  .MetaTestOptIn.json (issue #211).
- Opt-in for the test "Common Tests - Spellcheck Markdown Files", and added the
  settings file `.vscode\cSpell.json`.
- Move section Phased Meta test Opt-In in the README.md, and renamed it to
  Common Meta test Opt-In  (issue #281).

Fixes #211
Fixes #281

*Worked on this last evening, there are a bug with this, but sending this in so it is not forgotten in my fork.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/279)
<!-- Reviewable:end -->
