### PR TITLE
Added RequiredVersion for PSPKI

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -16,7 +16,8 @@
         "PSSA",
         "Dism",
         "vors",
-        "subfolders"
+        "subfolders",
+        "PSPKI"
     ],
     "ignoreRegExpList": [
         "AppVeyor",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added the ability to temporary skip common test for debugging purposes
   ([issue #219](https://github.com/PowerShell/DscResource.Tests/issues/219)).
 - Added a RequiredVersion for PSPKI in TestHelper because of a critical issue
-  in the recently released version of that module
+  in the recently released version of that module.
 
 ## 0.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added issue templates.
 - Added the ability to temporary skip common test for debugging purposes
   ([issue #219](https://github.com/PowerShell/DscResource.Tests/issues/219)).
+- Added a RequiredVersion for PSPKI in TestHelper because of a critical issue
+  in the recently released version of that module
 
 ## 0.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Added issue templates.
 - Added the ability to temporary skip common test for debugging purposes
   ([issue #219](https://github.com/PowerShell/DscResource.Tests/issues/219)).
-- Added a RequiredVersion for PSPKI in TestHelper because of a critical issue
-  in the recently released version of that module.
+- Added a RequiredVersion for PSPKI (v3.3.0.0) in TestHelper because of a critical
+  issue in the recently released version (v3.4.0.1) of that module.
 
 ## 0.3.0.0
 

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -1834,7 +1834,7 @@ function New-DscSelfSignedCertificate
                 There are build workers still on Windows Server 2012 R2 so let's
                 use the alternate method of New-SelfSignedCertificate.
             #>
-            Install-Module -Name PSPKI -Scope CurrentUser
+            Install-Module -Name PSPKI -Scope CurrentUser -RequiredVersion 3.3.0.0
             Import-Module -Name PSPKI
 
             $newSelfSignedCertificateExParameters = @{


### PR DESCRIPTION
#### Pull Request (PR) description
The version of PSPKI that was released on Oct 15th has an issue in New-SelfsignedCertificateEx, which is blocking PRs from being successfully tested: https://github.com/Crypt32/PSPKI/issues/56

This PR forces the use of v3.3.0.0, in which the tests work fine.

Can this PR please be reviewed and merged soon, since this issue is blocking all PRs in SharePointDsc

#### This Pull Request (PR) fixes the following issues
N/A

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [X] Documentation added/updated in README.md.
- [X] Comment-based help added/updated for all new/changed functions.
- [X] Localization strings added/updated in all localization files as appropriate.
- [X] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/304)
<!-- Reviewable:end -->
