### PR TITLE
Fixes issue where Reset-DSC causes a Warning to be logged if a DSC configuration is not currently running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixes issue where Reset-DSC causes a Warning to be logged if a DSC
+  configuration is not currently running.
 - Added issue templates.
 - Added the ability to temporary skip common test for debugging purposes
   ([issue #219](https://github.com/PowerShell/DscResource.Tests/issues/219)).

--- a/TestHelper.psm1
+++ b/TestHelper.psm1
@@ -483,7 +483,7 @@ function Reset-DSC {
 
     Write-Verbose -Message 'Resetting the DSC LCM'
 
-    Stop-DscConfiguration -ErrorAction 'SilentlyContinue' -Force
+    Stop-DscConfiguration -ErrorAction 'SilentlyContinue' -WarningAction 'SilentlyContinue' -Force
     Remove-DscConfigurationDocument -Stage 'Current' -Force
     Remove-DscConfigurationDocument -Stage 'Pending' -Force
     Remove-DscConfigurationDocument -Stage 'Previous' -Force


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where Reset-DSC causes a Warning to be logged if a DSC configuration is not currently running

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/316)
<!-- Reviewable:end -->
