### PR TITLE
Test-PublishMetadata: Add Processing for InvalidGUID Error from Test-ScriptFileInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added processing to `Test-PublishMetaData` for the InvalidGUID error from Test-ScriptFileInfo ([issue #330](https://github.com/PowerShell/DscResource.Tests/issues/330)).
 - Fixes issue where Reset-DSC causes a Warning to be logged if a DSC
   configuration is not currently running.
 - Added issue templates.

--- a/DscResource.GalleryDeploy/DscResource.GalleryDeploy.psm1
+++ b/DscResource.GalleryDeploy/DscResource.GalleryDeploy.psm1
@@ -289,10 +289,16 @@ function Test-PublishMetadata
                         $skipWarningMessage, ($script:localizedData.MissingRequiredMetadataProperties -f $errorMessage))
             }
 
+            'InvalidGuid,Test-ScriptFileInfo'
+            {
+                Write-Warning -Message ('{0} {1}' -f `
+                        $skipWarningMessage, ($script:localizedData.InvalidGuid -f $errorMessage))
+            }
+
             default
             {
                 # If the error is not recognized then throw.
-                throw $_
+                throw ($script:localizedData.TestScriptFileInfoError -f $Path, $_)
             }
         }
     }

--- a/DscResource.GalleryDeploy/en-US/DscResource.GalleryDeploy.strings.psd1
+++ b/DscResource.GalleryDeploy/en-US/DscResource.GalleryDeploy.strings.psd1
@@ -1,18 +1,20 @@
 ConvertFrom-StringData @'
 # English strings
-CannotPublish = Cannot publish to PowerShell Gallery.
-FoundApiKey = Found API key to use for publishing to the PowerShell Gallery.
-MissingApiKey = Missing API key in $env:gallery_api.
-EvaluatingExamples = Evaluating examples that end with 'Config' if they need publishing.
-NotOnMasterBranch = Not running against the branch 'master'. Will run Publish-Script with parameter WhatIf.
-MissingExampleValidationOptIn = Examples will not publish unless repository has opt-in for example validation. To opt-in, create a '.MetaTestOptIn.json' at the root of the repo in the following format: ["{0}"]
-SkipPublish = Skipping publishing example '{0}'.
-ScriptParseError = The example could not be read, for example if there is a required module missing when the script should be parsed, or general script parsing errors. General errors should have been caught with the common example validation test. Error: {0}
-MissingMetadata = The example has not opt-in by adding script metadata to the example. Error: {0}
+CannotPublish                     = Cannot publish to PowerShell Gallery.
+FoundApiKey                       = Found API key to use for publishing to the PowerShell Gallery.
+MissingApiKey                     = Missing API key in $env:gallery_api.
+EvaluatingExamples                = Evaluating examples that end with 'Config' if they need publishing.
+NotOnMasterBranch                 = Not running against the branch 'master'. Will run Publish-Script with parameter WhatIf.
+MissingExampleValidationOptIn     = Examples will not publish unless repository has opt-in for example validation. To opt-in, create a '.MetaTestOptIn.json' at the root of the repo in the following format: ["{0}"]
+SkipPublish                       = Skipping publishing example '{0}'.
+TestScriptFileInfoError           = Error testing example '{0}'. {1}.
+ScriptParseError                  = The example could not be read, for example if there is a required module missing when the script should be parsed, or general script parsing errors. General errors should have been caught with the common example validation test. Error: {0}
+MissingMetadata                   = The example has not opt-in by adding script metadata to the example. Error: {0}
 MissingRequiredMetadataProperties = The example is missing needed metadata properties. This can also happen if code is checked out with just LF instead of CRLF (make sure core.autocrlf is set to true). Error: {0}
-ConfigurationNameMismatch = The configuration name and the file name are not the same, or the name does not contain only letters, numbers, and underscores. The name must also start with a letter, and it must end with a letter or a number.
-AddingExampleToBePublished = Adding the example '{0}' to the list to be published.
-DuplicateGuid = Skipping examples that was found having the same GUID. Duplicate examples: '{0}'.
-ExampleIsAlreadyPublished = The example '{0}' is already published (same version).
-PublishExample = The example '{0}' with version '{1}' is being published as '{2}'.
+InvalidGuid                       = The example has an invalid GUID. The format must be [XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX] where X is a hex digit (0,1,2,3,4,5,6,7,8,9,A,B,C,D,E,F). Error: {0}
+ConfigurationNameMismatch         = The configuration name and the file name are not the same, or the name does not contain only letters, numbers, and underscores. The name must also start with a letter, and it must end with a letter or a number.
+AddingExampleToBePublished        = Adding the example '{0}' to the list to be published.
+DuplicateGuid                     = Skipping examples that was found having the same GUID. Duplicate examples: '{0}'.
+ExampleIsAlreadyPublished         = The example '{0}' is already published (same version).
+PublishExample                    = The example '{0}' with version '{1}' is being published as '{2}'.
 '@


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds processing to `Test-PublishMetaData` for the `InvalidGUID` error from `Test-ScriptFileInfo`. It also improves the unknown error message by adding file path information to the error message and updates the tests.

The `DscResource.GalleryDeploy/en-US/DscResource.GalleryDeploy.strings.psd1` strings were also aligned for readability.

#### This Pull Request (PR) fixes the following issues

- Fixes #330 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/331)
<!-- Reviewable:end -->
