### PR TITLE
New-DscResourcePowerShellHelp: Restore OutputPath parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
       file that do not exist in the en-US resource file.
 - Added `Publish-WikiContent` helper function to publish auto-generated Wiki files
   to the relevant DSC resource GitHub Wiki ([issue #142](https://github.com/PowerShell/DscResource.Tests/issues/142)).
-- Update New-DscResourcePowerShellHelp to output the PowerShell help files to
+- Update New-DscResourcePowerShellHelp to optionally output the PowerShell help files to
   the resource specific path and fix the example processing.
 - Added processing to `Test-PublishMetaData` for the InvalidGUID error from Test-ScriptFileInfo
   ([issue #330](https://github.com/PowerShell/DscResource.Tests/issues/330)).

--- a/Tests/Unit/DscResource.DocumentationHelper.Tests.ps1
+++ b/Tests/Unit/DscResource.DocumentationHelper.Tests.ps1
@@ -924,7 +924,7 @@ Configuration CertificateExport_CertByFriendlyName_Config
         $mockGitUserEmail = 'mock@contoso.com'
         $mockGitUserName = 'mock'
         $mockGithubAccessToken = '1234567890'
-        $mockPath = "C:\Windows\Temp"
+        $mockPath = $env:temp
         $mockJobId = 'imy2wgh1ylo9qcpb'
         $mockBuildVersion = '2.1.456.0'
         $mockapiUrl = 'https://ci.appveyor.com/api'
@@ -1383,6 +1383,7 @@ Configuration Example
     $script:mockReadmePath = Join-Path -Path $script:mockSchemaFolder -ChildPath 'readme.md'
     $script:mockOutputFile = Join-Path -Path $script:mockOutputPath -ChildPath "$($script:mockResourceName).md"
     $script:mockSavePath = Join-Path -Path $script:mockModulePath -ChildPath "DscResources\$($script:mockResourceName)\en-US\about_$($script:mockResourceName).help.txt"
+    $script:mockOutputSavePath = Join-Path -Path $script:mockOutputPath -ChildPath "about_$($script:mockResourceName).help.txt"
     $script:mockGetContentReadme = '# Description
 
 The description of the resource.'
@@ -1455,6 +1456,10 @@ Configuration Example
             $InputObject -eq $script:mockPowerShellHelpOutput -and
             $FilePath -eq $script:mockSavePath
         }
+        $script:outFileOutputInputObject_parameterFilter = {
+            $InputObject -eq $script:mockPowerShellHelpOutput -and
+            $FilePath -eq $script:mockOutputSavePath
+        }
         $script:writeWarningDescription_parameterFilter = {
             $Message -eq ($script:localizedData.NoDescriptionFileFoundWarning -f $mockResourceName)
         }
@@ -1464,6 +1469,10 @@ Configuration Example
         # Function call parameters
         $script:newDscResourcePowerShellHelp_parameters = @{
             ModulePath = $script:mockModulePath
+        }
+        $script:newDscResourcePowerShellHelpOutput_parameters = @{
+            ModulePath = $script:mockModulePath
+            OutputPath = $script:mockOutputPath
         }
 
         Context 'When there is no schemas found in the module folder' {
@@ -1621,7 +1630,7 @@ Configuration Example
                 }
         }
 
-        Context 'When there is one schema found in the module folder and one example using .EXAMPLE' {
+        Context 'When there is one schema found in the module folder and one example using .EXAMPLE and the OutputPath is specified' {
             BeforeAll {
                 Mock `
                     -CommandName Get-ChildItem `
@@ -1654,8 +1663,105 @@ Configuration Example
                     -MockWith { $script:mockExampleContent }
 
                 Mock `
+                    -CommandName Out-File
+
+                Mock `
+                    -CommandName Write-Warning `
+                    -ParameterFilter $script:writeWarningExample_parameterFilter
+
+                Mock `
+                    -CommandName Write-Warning `
+                    -ParameterFilter $script:writeWarningDescription_parameterFilter
+            }
+
+            It 'Should not throw an exception' {
+                { New-DscResourcePowerShellHelp @script:newDscResourcePowerShellHelpOutput_parameters } | Should -Not -Throw
+            }
+
+            It 'Should produce the correct output' {
+                Assert-MockCalled `
                     -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
+                    -ParameterFilter $script:outFileOutputInputObject_parameterFilter `
+                    -Exactly -Times 1
+            }
+
+            It 'Should call the expected mocks ' {
+                Assert-MockCalled `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-MofSchemaObject `
+                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterfilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Test-Path `
+                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -Exactly -Times 1
+
+                 Assert-MockCalled `
+                    -CommandName Get-Content `
+                    -ParameterFilter $script:getContentReadme_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemExample_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-DscResourceHelpExampleContent `
+                    -ParameterFilter $script:getDscResourceHelpExampleContent_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Write-Warning `
+                    -ParameterFilter $script:writeWarningExample_parameterFilter `
+                    -Exactly -Times 0
+
+                Assert-MockCalled `
+                    -CommandName Write-Warning `
+                    -ParameterFilter $script:writeWarningDescription_parameterFilter `
+                    -Exactly -Times 0
+            }
+        }
+
+        Context 'When there is one schema found in the module folder and one example using .EXAMPLE and the OutputPath is not specified' {
+            BeforeAll {
+                Mock `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemSchema_parameterFilter `
+                    -MockWith { $script:mockSchemaFiles }
+
+                Mock `
+                    -CommandName Get-MofSchemaObject `
+                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterfilter `
+                    -MockWith { $script:mockGetMofSchemaObject }
+
+                Mock `
+                    -CommandName Test-Path `
+                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
+                    -MockWith { $true }
+
+                Mock `
+                    -CommandName Get-Content `
+                    -ParameterFilter $script:getContentReadme_parameterFilter `
+                    -MockWith { $script:mockGetContentReadme }
+
+                Mock `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $script:getChildItemExample_parameterFilter `
+                    -MockWith { $script:mockExampleFiles }
+
+                Mock `
+                    -CommandName Get-DscResourceHelpExampleContent `
+                    -ParameterFilter $script:getDscResourceHelpExampleContent_parameterFilter `
+                    -MockWith { $script:mockExampleContent }
+
+                Mock `
+                    -CommandName Out-File
 
                 Mock `
                     -CommandName Write-Warning `
@@ -1693,7 +1799,7 @@ Configuration Example
                     -ParameterFilter $script:getTestPathReadme_parameterFilter `
                     -Exactly -Times 1
 
-                 Assert-MockCalled `
+                Assert-MockCalled `
                     -CommandName Get-Content `
                     -ParameterFilter $script:getContentReadme_parameterFilter `
                     -Exactly -Times 1


### PR DESCRIPTION
#### Pull Request (PR) description

This PR restores the `OutputPath` parameter to the `New-DscResourcePowerShellHelp` function that was removed as part of PR #325.
If the `OutputPath` parameter is specified, all the PowerShell help files are output to this path. If the `OutputPath` parameter is not specified, the PowerShell help files are output to each individual resource's en-US folder.

#### This Pull Request (PR) fixes the following issues

- Fixes #332

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/334)
<!-- Reviewable:end -->
