### PR TITLE
README.md: Move Publish Wiki Content section & Remove Legacy CHANGELOG Link from ToC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Added PowerShell Script Analyzer rules to check the following
   statements are in lower case: `if`,`foreach`,`do`,`while`,`for`,
   `try`,`catch`,`enum`,`class` ([issue #224](https://github.com/PowerShell/DscResource.Tests/issues/224)).
+- Moved `Publish Wiki Content` section in the `README.md` to the correct location.
 
 ## 0.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
   statements are in lower case: `if`,`foreach`,`do`,`while`,`for`,
   `try`,`catch`,`enum`,`class` ([issue #224](https://github.com/PowerShell/DscResource.Tests/issues/224)).
 - Moved `Publish Wiki Content` section in the `README.md` to the correct location.
+- Removed the legacy `CHANGELOG` link in the README.md table of contents.
 
 ## 0.3.0.0
 

--- a/README.md
+++ b/README.md
@@ -805,39 +805,6 @@ environment:
 * text eol=crlf
 ```
 
-### Publish Wiki Content
-
-To opt-in to this task, change the appveyor.yml to include the opt-in task
-*PublishWikiContent*, e.g. `Invoke-AppVeyorDeployTask -OptIn PublishWikiContent`.
-
-By opting-in to the *PublishWikiContent* task, the test framework will publish the
-contents of a DSC Resource Module Wiki Content artifact to the relevant GitHub Wiki
-repository, but only if it is a 'master' branch build (`$env:APPVEYOR_REPO_BRANCH -eq 'master'`).
-A Wiki Sidebar file will be generated, containing links to all of the markdown
-files in the Wiki, as well as as a Wiki Footer file. Any files contained within the
-`WikiSource` directory of the repository will also be published to the Wiki
-overriding any auto generated files.
-
-> **Note:** It is possible to override the deploy branch in appveyor.yml,
-> e.g. `Invoke-AppVeyorDeployTask -Branch @('dev','my-working-branch')`.
-
-#### Requirements/dependencies for publishing Wiki Content
-
-- Publish only on 'master' build.
-- The `Invoke-AppveyorAfterTestTask` function must be present in the Appveyor
-  configuration with a Type of 'Wiki' to generate the Wiki artifact.
-- A GitHub Personal Access Token with `repo/public_repo` permissions for a user
-  that has at least `Collaborator` access to the relevant DSC Module GitHub repository
-  must be generated and then added as a
-  [secure variable](https://www.appveyor.com/docs/build-configuration/#secure-variables)
-  called `github_access_token` to the `environment` section of the repository's
-  `appveyor.yml` file.
-- The GitHub Wiki needs to be initialized on a repository before this function is run.
-
-> **Note:** Currently Wiki content files are only added or updated by the function,
-> not deleted. Any deletions must be done manually by cloning the Wiki repository and
-> deleting the required content.
-
 #### Contributor responsibilities
 
 Contributors that add or change an example to be published must make sure that
@@ -897,3 +864,36 @@ Contributors that add or change an example to be published must make sure that
         Defaults to 'Just some sample text to write to the file'.
 #>
 ```
+
+### Publish Wiki Content
+
+To opt-in to this task, change the appveyor.yml to include the opt-in task
+*PublishWikiContent*, e.g. `Invoke-AppVeyorDeployTask -OptIn PublishWikiContent`.
+
+By opting-in to the *PublishWikiContent* task, the test framework will publish the
+contents of a DSC Resource Module Wiki Content artifact to the relevant GitHub Wiki
+repository, but only if it is a 'master' branch build (`$env:APPVEYOR_REPO_BRANCH -eq 'master'`).
+A Wiki Sidebar file will be generated, containing links to all of the markdown
+files in the Wiki, as well as as a Wiki Footer file. Any files contained within the
+`WikiSource` directory of the repository will also be published to the Wiki
+overriding any auto generated files.
+
+> **Note:** It is possible to override the deploy branch in appveyor.yml,
+> e.g. `Invoke-AppVeyorDeployTask -Branch @('dev','my-working-branch')`.
+
+#### Requirements/dependencies for publishing Wiki Content
+
+- Publish only on 'master' build.
+- The `Invoke-AppveyorAfterTestTask` function must be present in the Appveyor
+  configuration with a Type of 'Wiki' to generate the Wiki artifact.
+- A GitHub Personal Access Token with `repo/public_repo` permissions for a user
+  that has at least `Collaborator` access to the relevant DSC Module GitHub repository
+  must be generated and then added as a
+  [secure variable](https://www.appveyor.com/docs/build-configuration/#secure-variables)
+  called `github_access_token` to the `environment` section of the repository's
+  `appveyor.yml` file.
+- The GitHub Wiki needs to be initialized on a repository before this function is run.
+
+> **Note:** Currently Wiki content files are only added or updated by the function,
+> not deleted. Any deletions must be done manually by cloning the Wiki repository and
+> deleting the required content.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ A full list of changes in each version can be found in the [change log](CHANGELO
 - [Deploy](#deploy)
   - [Publish examples to PowerShell Gallery](#publish-examples-to-powershell-gallery)
   - [Publish Wiki Content](#publish-wiki-content)
-- [Change Log](#change-log)
 
 <!-- /TOC -->
 


### PR DESCRIPTION
#### Pull Request (PR) description

The `Publish Wiki Content` section in the `README.md` was incorrectly added in the middle of the `Publish examples to PowerShell Gallery` section. This PR fixes this by moving it to after that section.

The legacy `CHANGELOG` link in the table of contents has also been removed.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/342)
<!-- Reviewable:end -->
