### PR TITLE
PSScriptAnalyzer: One Space Between Keyword and Parenthesis check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 - Moved `Publish Wiki Content` section in the `README.md` to the correct location.
 - Removed the legacy `CHANGELOG` link in the `README.md` table of contents.
 - Fixed broken links and formatting in the `README.md` file.
-- Added Measure-Keyword function to check if all keywords are in lower case.
+- Added Measure-Keyword function to check if all keywords are in lower case and if followed by parentheses, that there is a single space in between.
 
 ## 0.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@
 - Moved `Publish Wiki Content` section in the `README.md` to the correct location.
 - Removed the legacy `CHANGELOG` link in the `README.md` table of contents.
 - Fixed broken links and formatting in the `README.md` file.
-- Added Measure-Keyword function to check if all keywords are in lower case and if followed by parentheses, that there is a single space in between.
+- Added Measure-Keyword function to check if all keywords are in lower case.
+  - If a keyword is followed by parentheses,there should be a single space between them.
 
 ## 0.3.0.0
 

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1036,14 +1036,23 @@ function Measure-Keyword
         $script:diagnosticRecord['RuleName'] = $PSCmdlet.MyInvocation.InvocationName
 
         $keywordFlag = [System.Management.Automation.Language.TokenFlags]::Keyword
-        $upperCaseTokens = $Token.Where( { $_.TokenFlags.HasFlag($keywordFlag) -and $_.Text -cmatch '[A-Z]+' })
+        $keywords = $Token.Where{ $_.TokenFlags.HasFlag($keywordFlag) }
+        $upperCaseTokens = $keywords.Where{ $_.Text -cmatch '[A-Z]+' }
+
+        $tokenWithNoSpace = $keywords.Where{ $_.Extent.StartScriptPosition.Line -match '[a-z]+\(.*' }
 
         foreach ($item in $upperCaseTokens)
         {
             $script:diagnosticRecord['Extent'] = $item.Extent
             $script:diagnosticRecord['Message'] = $localizedData.StatementsContainsUpperCaseLetter -f $item.Text
             $script:diagnosticRecord -as $diagnosticRecordType
-        } #if
+        }
+        foreach ($item in $tokenWithNoSpace)
+        {
+            $script:diagnosticRecord['Extent'] = $item.Extent
+            $script:diagnosticRecord['Message'] = $localizedData.OneSpaceBetweenKeywordAndParenthesis
+            $script:diagnosticRecord -as $diagnosticRecordType
+        }
     }
     catch
     {

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1047,6 +1047,7 @@ function Measure-Keyword
             $script:diagnosticRecord['Message'] = $localizedData.StatementsContainsUpperCaseLetter -f $item.Text
             $script:diagnosticRecord -as $diagnosticRecordType
         }
+
         foreach ($item in $tokenWithNoSpace)
         {
             $script:diagnosticRecord['Extent'] = $item.Extent

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1039,7 +1039,7 @@ function Measure-Keyword
         $keywords = $Token.Where{ $_.TokenFlags.HasFlag($keywordFlag) }
         $upperCaseTokens = $keywords.Where{ $_.Text -cmatch '[A-Z]+' }
 
-        $tokenWithNoSpace = $keywords.Where{ $_.Extent.StartScriptPosition.Line -match '[a-z]+\(.*' }
+        $tokenWithNoSpace = $keywords.Where{ $_.Extent.StartScriptPosition.Line -match "$($_.Extent.Text)\(.*" }
 
         foreach ($item in $upperCaseTokens)
         {

--- a/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
@@ -42,4 +42,5 @@ EnumOpeningBraceShouldBeFollowedByOnlyOneNewLine = Opening brace on Enum should 
 ClassOpeningBraceNotOnSameLine = Class should not have the open brace on the same line as the declaration. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-before-braces
 ClassOpeningBraceShouldBeFollowedByNewLine = Opening brace on Class should be followed by a new line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
 ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine = Opening brace on Class should only be followed by one new line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
+OneSpaceBetweenKeywordAndParenthesis = If a keyword is followed by a parenthesis, there should be single space between the keyword and the parenthesis. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
 '@

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3367,6 +3367,7 @@ Describe 'Measure-Keyword' {
         BeforeAll {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
+                IncludeRule    = 'Measure-Keyword'
             }
             $ruleName = "$($script:ModuleName)\Measure-Keyword"
         }

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3315,12 +3315,44 @@ Describe 'Measure-Keyword' {
             }
         }
 
+        Context 'When keyword is not followed by a single space' {
+            It 'Should write the correct error record' {
+                $definition = '
+                        if("example" -eq "example" -or "magic")
+                        {
+                            Write-Verbose -Message "Example found."
+                        }
+                    '
+
+                $token = Get-TokensFromDefinition -ScriptDefinition $definition
+                $record = Measure-Keyword -Token $token
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.OneSpaceBetweenKeywordAndParenthesis
+                $record.RuleName | Should -Be $ruleName
+            }
+        }
+
         Context 'When keyword does not contain upper case letters' {
             It 'Should not return an error record' {
                 $definition = '
                         function Test
                         {
                            return $true
+                        }
+                    '
+
+                $token = Get-TokensFromDefinition -ScriptDefinition $definition
+                $record = Measure-Keyword -Token $token
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+        }
+
+        Context 'When keyword is followed by a single space' {
+            It 'Should not return an error record' {
+                $definition = '
+                        if ("example" -eq "example" -or "magic")
+                        {
+                            Write-Verbose -Message "Example found."
                         }
                     '
 
@@ -3356,9 +3388,25 @@ Describe 'Measure-Keyword' {
                 }
             }
 
+            Context 'When keyword is not followed by a single space' {
+                It 'Should write the correct error record' {
+                    $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                            if("example" -eq "example" -or "magic")
+                            {
+                                Write-Verbose -Message "Example found."
+                            }
+                        '
+
+                    $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                    ($record | Measure-Object).Count | Should -Be 1
+                    $record.Message | Should -Be $localizedData.OneSpaceBetweenKeywordAndParenthesis
+                    $record.RuleName | Should -Be $ruleName
+                }
+            }
+
             Context 'When keyword does not contain upper case letters' {
                 It 'Should not return an error record' {
-                    $definition = '
+                    $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                             function Test
                             {
                                return $true
@@ -3366,9 +3414,22 @@ Describe 'Measure-Keyword' {
                         '
 
                     $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
-                    ($record | Measure-Object).Count | Should -BeExactly 1
+                    ($record | Measure-Object).Count | Should -BeExactly 0
                 }
-        }
+            }
+
+            Context 'When keyword is followed by a single space' {
+                It 'Should not return an error record' {
+                    $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                            if ("example" -eq "example" -or "magic")
+                            {
+                                Write-Verbose -Message "Example found."
+                            }
+                        '
+                    $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                    ($record | Measure-Object).Count | Should -Be 0
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
One Space Between Keyword and Parenthesis
If a keyword is followed by a parenthesis, there should be single space between the keyword and the parenthesis.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/347)
<!-- Reviewable:end -->
