### PR TITLE
Hashtables - correct formatting check

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -19,7 +19,8 @@
         "subfolders",
         "PSPKI",
         "gitignore",
-        "Nuget"
+        "Nuget",
+        "Hashtable"
     ],
     "ignoreRegExpList": [
         "AppVeyor",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.whitespaceInsideBrace": false,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
     "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Fixed broken links and formatting in the `README.md` file.
 - Added Measure-Keyword function to check if all keywords are in lower case.
   - If a keyword is followed by parentheses,there should be a single space between them.
+- Added Measure-Hashtable function to check if a hashtable is correctly formatted.
 
 ## 0.3.0.0
 

--- a/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
+++ b/DscResource.AnalyzerRules/en-US/DscResource.AnalyzerRules.psd1
@@ -43,4 +43,5 @@ ClassOpeningBraceNotOnSameLine = Class should not have the open brace on the sam
 ClassOpeningBraceShouldBeFollowedByNewLine = Opening brace on Class should be followed by a new line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
 ClassOpeningBraceShouldBeFollowedByOnlyOneNewLine = Opening brace on Class should only be followed by one new line. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
 OneSpaceBetweenKeywordAndParenthesis = If a keyword is followed by a parenthesis, there should be single space between the keyword and the parenthesis. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#one-newline-after-opening-brace
+HashtableShouldHaveCorrectFormat = Hashtable is not correctly formatted. See https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-format-for-hashtables-or-objects
 '@

--- a/DscResource.CodeCoverage/CodeCovIo.psm1
+++ b/DscResource.CodeCoverage/CodeCovIo.psm1
@@ -71,12 +71,17 @@ function Add-UniqueFileLineToTable
 
             if (!$FileLine.ContainsKey($fileKey))
             {
-                $FileLine.add($fileKey, @{ $TableName = @{ } })
+                $FileLine.add(
+                    $fileKey,
+                    @{
+                        $TableName = @{}
+                    }
+                )
             }
 
             if (!$FileLine.$fileKey.ContainsKey($TableName))
             {
-                $FileLine.$fileKey.Add($TableName, @{ })
+                $FileLine.$fileKey.Add($TableName, @{})
             }
 
             $lines = $FileLine.($fileKey).$TableName
@@ -176,7 +181,7 @@ function Export-CodeCovIoJson
     }
 
     # A table of the file key then a sub-tables of `misses` and `hits` lines.
-    $FileLine = @{ }
+    $FileLine = @{}
 
     # define common parameters
     $addUniqueFileLineParams = @{
@@ -194,8 +199,8 @@ function Export-CodeCovIoJson
     Add-UniqueFileLineToTable -Command $CodeCoverage.HitCommands -TableName 'hits' @addUniqueFileLineParams
 
     # Create the results structure
-    $resultLineData = @{ }
-    $resultMessages = @{ }
+    $resultLineData = @{}
+    $resultMessages = @{}
     $result = @{
         coverage = $resultLineData
         messages = $resultMessages
@@ -209,14 +214,14 @@ function Export-CodeCovIoJson
         Write-Verbose -Message "summarizing for file: $file"
 
         # Get the hits, if they exist
-        $hits = @{ }
+        $hits = @{}
         if ($FileLine.$file.ContainsKey('hits'))
         {
             $hits = $FileLine.$file.hits
         }
 
         # Get the misses, if they exist
-        $misses = @{ }
+        $misses = @{}
         if ($FileLine.$file.ContainsKey('misses'))
         {
             $misses = $FileLine.$file.misses
@@ -236,7 +241,7 @@ function Export-CodeCovIoJson
         }
 
         $lineData = @()
-        $messages = @{ }
+        $messages = @{}
 
         <#
             produce the results

--- a/DscResource.Container/DscResource.Container.psm1
+++ b/DscResource.Container/DscResource.Container.psm1
@@ -724,7 +724,8 @@ function Out-MissedCommand
 
         [PSCustomObject[]] $MissedCommand = $MissedCommand |
             Select-Object -Property @{
-                Name = 'File'; Expression = {
+                Name       = 'File'
+                Expression = {
                     $_.File -replace ("$env:APPVEYOR_BUILD_FOLDER\" -replace '\\', '\\')
                 }
             }, Function, Line, Command

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3436,8 +3436,7 @@ Describe 'Measure-Keyword' {
 }
 
 Describe 'Measure-Hashtable' {
-
-    Context "When calling the function directly" {
+    Context 'When calling the function directly' {
         BeforeAll {
             $ruleName = 'Measure-Hashtable'
             $astType = 'System.Management.Automation.Language.HashtableAst'
@@ -3485,9 +3484,22 @@ Describe 'Measure-Hashtable' {
                 $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
                 $record.RuleName | Should -Be $ruleName
             }
+
+            It 'Correctly formatted empty hashtable' {
+                $definition = '
+                        $hashtable = @{ }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+
+            }
         }
 
-        Context "When hashtable is correctly formatted" {
+        Context 'When hashtable is correctly formatted' {
             It "Correctly formatted non-nested hashtable" {
                 $definition = '
                         $hashtable = @{
@@ -3501,7 +3513,8 @@ Describe 'Measure-Hashtable' {
                 $record = Measure-Hashtable -HashtableAst $mockAst
                 ($record | Measure-Object).Count | Should -Be 0
             }
-            It "Correctly formatted nested hashtable" {
+
+            It 'Correctly formatted nested hashtable' {
                 $definition = '
                         $hashtable = @{
                             Key1 = "Value1"
@@ -3517,17 +3530,28 @@ Describe 'Measure-Hashtable' {
                 $record = Measure-Hashtable -HashtableAst $mockAst
                 ($record | Measure-Object).Count | Should -Be 0
             }
+
+            It 'Correctly formatted empty hashtable' {
+                $definition = '
+                        $hashtable = @{}
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 0
+            }
         }
     }
 
-    Context "When calling PSScriptAnalyzer" {
+    Context 'When calling PSScriptAnalyzer' {
         BeforeAll {
             $invokeScriptAnalyzerParameters = @{
                 CustomRulePath = $modulePath
             }
             $ruleName = "$($script:ModuleName)\Measure-Hashtable"
         }
-         Context 'When hashtable is not correctly formatted' {
+
+        Context 'When hashtable is not correctly formatted' {
             It 'Hashtable defined on a single line' {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         $hashtable = @{Key1 = "Value1";Key2 = 2;Key3 = "3"}
@@ -3553,7 +3577,7 @@ Describe 'Measure-Hashtable' {
             }
 
             It 'Hashtable indentation not correct' {
-                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         $hashtable = @{
                             Key1 = "Value1"
                             Key2 = 2
@@ -3566,11 +3590,21 @@ Describe 'Measure-Hashtable' {
                 $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
                 $record.RuleName | Should -Be $ruleName
             }
+
+            It 'Incorrectly formatted empty hashtable' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        $hashtable = @{ }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
         }
 
-        Context "When hashtable is correctly formatted" {
-            It "Correctly formatted non-nested hashtable" {
-                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+        Context 'When hashtable is correctly formatted' {
+            It 'Correctly formatted non-nested hashtable' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         $hashtable = @{
                             Key1 = "Value1"
                             Key2 = 2
@@ -3581,8 +3615,9 @@ Describe 'Measure-Hashtable' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 0
             }
-            It "Correctly formatted nested hashtable" {
-                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+
+            It 'Correctly formatted nested hashtable' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         $hashtable = @{
                             Key1 = "Value1"
                             Key2 = 2
@@ -3591,6 +3626,15 @@ Describe 'Measure-Hashtable' {
                                 Key3Key2 = 42
                             }
                         }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+
+            It 'Correctly formatted empty hashtable' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        $hashtable = @{}
                     '
 
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3436,6 +3436,7 @@ Describe 'Measure-Keyword' {
 }
 
 Describe 'Measure-Hashtable' {
+
     Context "When calling the function directly" {
         BeforeAll {
             $ruleName = 'Measure-Hashtable'
@@ -3460,6 +3461,22 @@ Describe 'Measure-Hashtable' {
                         $hashtable = @{ Key1 = "Value1"
                         Key2 = 2
                         Key3 = "3" }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Hashtable indentation not correct' {
+                $definition = '
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                        Key3 = "3"
+                        }
                     '
 
                 $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
@@ -3498,6 +3515,85 @@ Describe 'Measure-Hashtable' {
 
                 $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
                 $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+        }
+    }
+
+    Context "When calling PSScriptAnalyzer" {
+        BeforeAll {
+            $invokeScriptAnalyzerParameters = @{
+                CustomRulePath = $modulePath
+            }
+            $ruleName = "$($script:ModuleName)\Measure-Hashtable"
+        }
+         Context 'When hashtable is not correctly formatted' {
+            It 'Hashtable defined on a single line' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        $hashtable = @{Key1 = "Value1";Key2 = 2;Key3 = "3"}
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Hashtable partially correct formatted' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        $hashtable = @{ Key1 = "Value1"
+                        Key2 = 2
+                        Key3 = "3" }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Hashtable indentation not correct' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                        Key3 = "3"
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+        }
+
+        Context "When hashtable is correctly formatted" {
+            It "Correctly formatted non-nested hashtable" {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                            Key3 = "3"
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+            It "Correctly formatted nested hashtable" {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] ='
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                            Key3 = @{
+                                Key3Key1 = "ExampleText"
+                                Key3Key2 = 42
+                            }
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 0
             }
         }

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3434,3 +3434,72 @@ Describe 'Measure-Keyword' {
         }
     }
 }
+
+Describe 'Measure-Hashtable' {
+    Context "When calling the function directly" {
+        BeforeAll {
+            $ruleName = 'Measure-Hashtable'
+            $astType = 'System.Management.Automation.Language.HashtableAst'
+        }
+
+        Context 'When hashtable is not correctly formatted' {
+            It 'Hashtable defined on a single line' {
+                $definition = '
+                        $hashtable = @{Key1 = "Value1";Key2 = 2;Key3 = "3"}
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Hashtable partially correct formatted' {
+                $definition = '
+                        $hashtable = @{ Key1 = "Value1"
+                        Key2 = 2
+                        Key3 = "3" }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+        }
+
+        Context "When hashtable is correctly formatted" {
+            It "Correctly formatted non-nested hashtable" {
+                $definition = '
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                            Key3 = "3"
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+            It "Correctly formatted nested hashtable" {
+                $definition = '
+                        $hashtable = @{
+                            Key1 = "Value1"
+                            Key2 = 2
+                            Key3 = @{
+                                Key3Key1 = "ExampleText"
+                                Key3Key2 = 42
+                            }
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

Hashtables and Objects should be written in the following format. Each property should be on its own line indented once.

$hashtable = @{
    Key1 = 'Value1'
    Key2 = 2
    Key3 = '3'
}

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/348)
<!-- Reviewable:end -->
