### PR TITLE
Hashtable formatting check: Ignore empty hashtables with white space inside

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -20,7 +20,8 @@
         "PSPKI",
         "gitignore",
         "Nuget",
-        "Hashtable"
+        "Hashtable",
+        "Hashtables"
     ],
     "ignoreRegExpList": [
         "AppVeyor",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Added Measure-Keyword function to check if all keywords are in lower case.
   - If a keyword is followed by parentheses,there should be a single space between them.
 - Added Measure-Hashtable function to check if a hashtable is correctly formatted.
+  - Emtpy hashtables with white space (@{ }) are ignored.
 - Turn on the Custom Script Analyzer Rules meta test.
 
 ## 0.3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 - Added Measure-Keyword function to check if all keywords are in lower case.
   - If a keyword is followed by parentheses,there should be a single space between them.
 - Added Measure-Hashtable function to check if a hashtable is correctly formatted.
-  - Emtpy hashtables with white space (@{ }) are ignored.
+  - Empty hashtables with white space are ignored.
 - Turn on the Custom Script Analyzer Rules meta test.
 
 ## 0.3.0.0

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1096,7 +1096,7 @@ function Measure-Hashtable
         foreach ($hashtable in $HashtableAst)
         {
             # Empty hashtables should be ignored
-            if ($hashtable.extent.Text -eq '@{}' -and $hashtable.extent.Text -eq '@{ }')
+            if ($hashtable.extent.Text -eq '@{}' -or $hashtable.extent.Text -eq '@{ }')
             {
                 continue
             }

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1096,7 +1096,7 @@ function Measure-Hashtable
         foreach ($hashtable in $HashtableAst)
         {
             # Empty hashtables should be ignored
-            if ($hashtable.extent.Text -eq '@{}')
+            if ($hashtable.extent.Text -eq '@{}' -and $hashtable.extent.Text -eq '@{ }')
             {
                 continue
             }

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3488,14 +3488,12 @@ Describe 'Measure-Hashtable' {
             It 'Correctly formatted empty hashtable' {
                 $definition = '
                         $hashtable = @{ }
+                        $hashtableNoSpace = @{}
                     '
 
                 $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
                 $record = Measure-Hashtable -HashtableAst $mockAst
-                ($record | Measure-Object).Count | Should -Be 1
-                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
-                $record.RuleName | Should -Be $ruleName
-
+                ($record | Measure-Object).Count | Should -Be 0
             }
         }
 
@@ -3533,7 +3531,8 @@ Describe 'Measure-Hashtable' {
 
             It 'Correctly formatted empty hashtable' {
                 $definition = '
-                        $hashtable = @{}
+                        $hashtableNoSpace = @{}
+                        $hashtable = @{ }
                     '
 
                 $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
@@ -3591,6 +3590,7 @@ Describe 'Measure-Hashtable' {
                 $record.RuleName | Should -Be $ruleName
             }
 
+            <# Commented out until PSSCriptAnalyzer fix is published.
             It 'Incorrectly formatted empty hashtable' {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         $hashtable = @{ }
@@ -3600,6 +3600,7 @@ Describe 'Measure-Hashtable' {
                 $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
                 $record.RuleName | Should -Be $ruleName
             }
+            #>
         }
 
         Context 'When hashtable is correctly formatted' {

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3635,7 +3635,8 @@ Describe 'Measure-Hashtable' {
 
             It 'Correctly formatted empty hashtable' {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
-                        $hashtable = @{}
+                        $hashtable = @{ }
+                        $hashtableNoSpace = @{}
                     '
 
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters


### PR DESCRIPTION
#### Pull Request (PR) description
This PR contains hotfix for the hashtable analyzer rule. 
All hashtables with white space inside will be ignored.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/353)
<!-- Reviewable:end -->
