### PR TITLE
Hashtable check - quick fix for LF end of line 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
   - DSC Keywords are ignored.
 - Added Measure-Hashtable function to check if a hashtable is correctly formatted.
   - Empty hashtables with white space are ignored.
-  - Fix issues with LF
+  - Fix issues with LF.
 - Turn on the Custom Script Analyzer Rules meta test.
 - Rewrite of Get-MofSchemaObject to use internal methods instead of text based parsing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
   - DSC Keywords are ignored.
 - Added Measure-Hashtable function to check if a hashtable is correctly formatted.
   - Empty hashtables with white space are ignored.
+  - Fix issues with LF
 - Turn on the Custom Script Analyzer Rules meta test.
 - Rewrite of Get-MofSchemaObject to use internal methods instead of text based parsing.
 

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1110,7 +1110,8 @@ function Measure-Hashtable
             $hashtableLines = $hashtable.Extent.Text -split '\n'
 
             # Hashtable should start with '@{' and end with '}'
-            if ($hashtableLines[0] -notmatch '@{\r' -or $hashtableLines[-1] -notmatch '\s*}')
+            if (($hashtableLines[0] -notmatch '@{\r' -and $hashtableLines[0] -notmatch '@{') -or
+                $hashtableLines[-1] -notmatch '\s*}')
             {
                 $script:diagnosticRecord['Extent'] = $hashtable.Extent
                 $script:diagnosticRecord['Message'] = $localizedData.HashtableShouldHaveCorrectFormat


### PR DESCRIPTION
#### Pull Request (PR) description
This PR extends the Measure-Hashtable function to cover LF end of line.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/355)
<!-- Reviewable:end -->
