### PR TITLE
Hashtable check - Fix for DSC composite resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Added Measure-Hashtable function to check if a hashtable is correctly formatted.
   - Empty hashtables with white space are ignored.
   - Fix issues with LF.
+  - Fix issue with DSC composite resources.
 - Turn on the Custom Script Analyzer Rules meta test.
 - Rewrite of Get-MofSchemaObject to use internal methods instead of text based parsing.
 

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1110,7 +1110,7 @@ function Measure-Hashtable
             $hashtableLines = $hashtable.Extent.Text -split '\n'
 
             # Hashtable should start with '@{' and end with '}'
-            if (($hashtableLines[0] -notmatch '@{\r' -and $hashtableLines[0] -notmatch '@{') -or
+            if (($hashtableLines[0] -notmatch '{\r' -and $hashtableLines[0] -notmatch '\s@?{$') -or
                 $hashtableLines[-1] -notmatch '\s*}')
             {
                 $script:diagnosticRecord['Extent'] = $hashtable.Extent

--- a/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
+++ b/DscResource.AnalyzerRules/DscResource.AnalyzerRules.psm1
@@ -1110,7 +1110,7 @@ function Measure-Hashtable
             $hashtableLines = $hashtable.Extent.Text -split '\n'
 
             # Hashtable should start with '@{' and end with '}'
-            if (($hashtableLines[0] -notmatch '{\r' -and $hashtableLines[0] -notmatch '\s@?{$') -or
+            if (($hashtableLines[0] -notmatch '\s*@?{\r' -and $hashtableLines[0] -notmatch '\s*@?{$') -or
                 $hashtableLines[-1] -notmatch '\s*}')
             {
                 $script:diagnosticRecord['Extent'] = $hashtable.Extent

--- a/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
+++ b/Tests/Unit/DscResource.AnalyzerRules.Tests.ps1
@@ -3537,6 +3537,62 @@ Describe 'Measure-Hashtable' {
             }
         }
 
+        Context 'When composite resource is not correctly formatted' {
+            It 'Composite resource defined on a single line' {
+                $definition = '
+                        configuration test {
+                            Script test
+                            { GetScript =  {}; SetScript = {}; TestScript = {}
+                            }
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Composite resource partially correct formatted' {
+                $definition = '
+                        configuration test {
+                            Script test
+                            { GetScript =  {}
+                                SetScript = {}
+                                TestScript = {}
+                            }
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Composite resource indentation not correct' {
+                $definition = '
+                        configuration test {
+                            Script test
+                            {
+                                GetScript =  {}
+                                 SetScript = {}
+                                  TestScript = {}
+                            }
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+        }
+
         Context 'When hashtable is correctly formatted' {
             It "Correctly formatted non-nested hashtable" {
                 $definition = '
@@ -3579,6 +3635,26 @@ Describe 'Measure-Hashtable' {
                 $record = Measure-Hashtable -HashtableAst $mockAst
                 ($record | Measure-Object).Count | Should -Be 0
             }
+        }
+
+        Context 'When composite resource is correctly formatted' {
+            It "Correctly formatted non-nested hashtable" {
+                $definition = '
+                        configuration test {
+                            Script test
+                            {
+                                GetScript = {};
+                                SetScript = {};
+                                TestScript = {}
+                            }
+                        }
+                    '
+
+                $mockAst = Get-AstFromDefinition -ScriptDefinition $definition -AstType $astType
+                $record = Measure-Hashtable -HashtableAst $mockAst
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+
         }
     }
 
@@ -3643,6 +3719,60 @@ Describe 'Measure-Hashtable' {
             #>
         }
 
+        Context 'When composite resource is not correctly formatted' {
+            It 'Composite resource defined on a single line' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        configuration test {
+                            Script test
+                            { GetScript =  {}; SetScript = {}; TestScript = {}
+                            }
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+
+            }
+
+            It 'Composite resource partially correct formatted' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        configuration test {
+                            Script test
+                            { GetScript =  {}
+                                SetScript = {}
+                                TestScript = {}
+                            }
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+            It 'Composite resource indentation not correct' {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        configuration test {
+                            Script test
+                            {
+                                GetScript =  {}
+                                 SetScript = {}
+                                  TestScript = {}
+                            }
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 1
+                $record.Message | Should -Be $localizedData.HashtableShouldHaveCorrectFormat
+                $record.RuleName | Should -Be $ruleName
+            }
+
+        }
+
         Context 'When hashtable is correctly formatted' {
             It 'Correctly formatted non-nested hashtable' {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
@@ -3682,6 +3812,25 @@ Describe 'Measure-Hashtable' {
                 $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
                 ($record | Measure-Object).Count | Should -Be 0
             }
+        }
+
+        Context 'When composite resource is correctly formatted' {
+            It "Correctly formatted non-nested hashtable" {
+                $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
+                        configuration test {
+                            Script test
+                            {
+                                GetScript = {};
+                                SetScript = {};
+                                TestScript = {}
+                            }
+                        }
+                    '
+
+                $record = Invoke-ScriptAnalyzer @invokeScriptAnalyzerParameters
+                ($record | Measure-Object).Count | Should -Be 0
+            }
+
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
As mentioned in this [PR](https://github.com/PowerShell/xPSDesiredStateConfiguration/pull/617), the DSC composite resources are also being parsed as hashtables. I have wrote a fix, that should remove the false/positives on those resources. 
I have tested it against few DSC Resources - I have not observed any false positives. 

#### This Pull Request (PR) fixes the following issues
[PR](https://github.com/PowerShell/xPSDesiredStateConfiguration/pull/617)

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/356)
<!-- Reviewable:end -->
