### PR TITLE
Fix Error with Wiki Content generation with Array in MOF - Fixes #357

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@
   - Fix issue with DSC composite resources.
 - Turn on the Custom Script Analyzer Rules meta test.
 - Rewrite of Get-MofSchemaObject to use internal methods instead of text based parsing.
+- Fixed error when generating Wiki content for MOF that contains an array type
+  ([issue #357](https://github.com/PowerShell/DscResource.Tests/issues/357)).
 
 ## 0.3.0.0
 

--- a/DscResource.DocumentationHelper/WikiPages.psm1
+++ b/DscResource.DocumentationHelper/WikiPages.psm1
@@ -96,7 +96,7 @@ function New-DscResourceWikiSite
 
                 if ($property.IsArray)
                 {
-                    $dataType += '[]'
+                    $dataType = $dataType.ToString() + '[]'
                 }
 
                 if ($property.EmbeddedInstance -eq 'MSFT_Credential')

--- a/Tests/Unit/DscResource.DocumentationHelper.Tests.ps1
+++ b/Tests/Unit/DscResource.DocumentationHelper.Tests.ps1
@@ -28,7 +28,7 @@ InModuleScope -ModuleName 'WikiPages' {
         Attributes   = @(
             @{
                 State            = 'Key'
-                DataType         = 'String'
+                DataType         = [Microsoft.Management.Infrastructure.CimType]::String
                 ValueMap         = @()
                 IsArray          = $false
                 Name             = 'Id'
@@ -37,7 +37,7 @@ InModuleScope -ModuleName 'WikiPages' {
             },
             @{
                 State            = 'Write'
-                DataType         = 'String'
+                DataType         = [Microsoft.Management.Infrastructure.CimType]::String
                 ValueMap         = @( 'Value1', 'Value2', 'Value3' )
                 IsArray          = $false
                 Name             = 'Enum'
@@ -45,8 +45,17 @@ InModuleScope -ModuleName 'WikiPages' {
                 EmbeddedInstance = ''
             },
             @{
+                State            = 'Write'
+                DataType         = [Microsoft.Management.Infrastructure.CimType]::String
+                ValueMap         = @()
+                IsArray          = $true
+                Name             = 'Array'
+                Description      = 'Array Description.'
+                EmbeddedInstance = ''
+            },
+            @{
                 State            = 'Required'
-                DataType         = 'Uint32'
+                DataType         = [Microsoft.Management.Infrastructure.CimType]::UInt32
                 ValueMap         = @()
                 IsArray          = $false
                 Name             = 'Int'
@@ -55,7 +64,7 @@ InModuleScope -ModuleName 'WikiPages' {
             },
             @{
                 State            = 'Read'
-                DataType         = 'String'
+                DataType         = [Microsoft.Management.Infrastructure.CimType]::String
                 ValueMap         = @()
                 IsArray          = $false
                 Name             = 'Read'
@@ -113,6 +122,7 @@ The description of the resource.
 | --- | --- | --- | --- | --- |
 | **Id** | Key | String | Id Description ||
 | **Enum** | Write | String | Enum Description. |Value1, Value2, Value3|
+| **Array** | Write | String[] | Array Description. ||
 | **Int** | Required | Uint32 | Int Description. ||
 | **Read** | Read | String | Read Description. ||
 
@@ -204,33 +214,28 @@ Configuration Example
                     -MockWith { $script:mockSchemaFiles }
 
                 Mock `
-                    -CommandName Get-MofSchemaObject `
-                    -ParameterFilter $script:getMofSchemaObjectSchema_parameterfilter `
-                    -MockWith { $script:mockGetMofSchemaObject }
-
-                Mock `
-                    -CommandName Test-Path `
-                    -ParameterFilter $script:getTestPathReadme_parameterFilter `
-                    -MockWith { $true }
-
-                Mock `
-                    -CommandName Get-Content `
-                    -ParameterFilter $script:getContentReadme_parameterFilter `
-                    -MockWith { $script:mockGetContentReadme }
-
-                Mock `
                     -CommandName Get-ChildItem `
                     -ParameterFilter $script:getChildItemExample_parameterFilter `
                     -MockWith { $script:mockExampleFiles }
 
                 Mock `
+                    -CommandName Get-MofSchemaObject `
+                    -MockWith { $script:mockGetMofSchemaObject }
+
+                Mock `
+                    -CommandName Test-Path `
+                    -MockWith { $true }
+
+                Mock `
+                    -CommandName Get-Content `
+                    -MockWith { $script:mockGetContentReadme }
+
+                Mock `
                     -CommandName Get-DscResourceWikiExampleContent `
-                    -ParameterFilter $script:getDscResourceWikiExampleContent_parameterFilter `
                     -MockWith { $script:mockExampleContent }
 
                 Mock `
-                    -CommandName Out-File `
-                    -ParameterFilter $script:outFile_parameterFilter
+                    -CommandName Out-File
             }
 
             It 'Should not throw an exception' {
@@ -1080,7 +1085,7 @@ Configuration CertificateExport_CertByFriendlyName_Config
                 BeforeAll {
                     Mock -CommandName Invoke-RestMethod `
                     -ParameterFilter $script:invokeRestMethodJobArtifacts_parameterFilter `
-                    -MockWith { Throw $mockInvokeRestMethodJobIdNotFoundMessage }
+                    -MockWith { throw $mockInvokeRestMethodJobIdNotFoundMessage }
                 }
 
                 It 'Should throw the correct exception' {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an error with Wiki Content generation when the MOF contains an array.

#### This Pull Request (PR) fixes the following issues

- Fxies #357 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one? It looks like it is breaking all repos that use auto docs and have an array in a MOF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.tests/358)
<!-- Reviewable:end -->
